### PR TITLE
feat: websocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+#backup
+/backup

--- a/src/app/@chatDialog/(.)chat/page.tsx
+++ b/src/app/@chatDialog/(.)chat/page.tsx
@@ -1,5 +1,6 @@
 import ChatPage from '@/app/chat/page';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { ChatFooterNavigation } from '@/features/chat';
 import { DialogDescription } from '@radix-ui/react-dialog';
 
 export default function ChatDialog() {
@@ -9,6 +10,7 @@ export default function ChatDialog() {
         <DialogTitle>chatDialog</DialogTitle>
         <DialogDescription></DialogDescription>
         <ChatPage />
+        <ChatFooterNavigation />
       </DialogContent>
     </Dialog>
   );

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,3 +1,37 @@
+'use client';
+import { useConnectWebSocket } from '@/features/chat/hooks/useConnectWebSocket';
+import { StompInitialRoomsType } from '@/features/chat/types/stomp';
+import { useEffect, useState } from 'react';
+
 export default function ChatPage() {
-  return <div>사실 이건 모달처럼 보이지만 채팅페이지임</div>;
+  const [rooms, setRooms] = useState<StompInitialRoomsType>([]);
+
+  const stompRef = useConnectWebSocket(
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiZW1haWwiOiJnYnRteGxmQG5hdmVyLmNvbSIsInVzZXJuYW1lIjoi7Jyg7ISg7ZalIiwibmlja25hbWUiOiLsnKDshKDtlqUiLCJ1c2VyUm9sZSI6IkFETUlOIiwidGllciI6Ik5FV0JJRSIsImV4cCI6MTc1MTAyNzQ5NywiaWF0IjoxNzUwNDIyNjk3fQ.GYBJkFE4Q_GyiRNjefuyanChGs4h0LJuRyzIrHTdJE0'
+  );
+
+  useEffect(() => {
+    if (!localStorage) return;
+    const chatRooms = localStorage.getItem('chatRooms')
+      ? (JSON.parse(localStorage.getItem('chatRooms')!) as StompInitialRoomsType)
+      : [];
+
+    setRooms(chatRooms);
+  }, [stompRef]);
+
+  return (
+    <div>
+      {rooms.length > 0 ? (
+        rooms.map((room) => {
+          return (
+            <div key={room.roomId}>
+              <p>{room.title}</p> <p>{room.roomId}</p>
+            </div>
+          );
+        })
+      ) : (
+        <div>생성된 채팅방이 없습니다.</div>
+      )}
+    </div>
+  );
 }

--- a/src/features/chat/hooks/useConnectWebSocket.ts
+++ b/src/features/chat/hooks/useConnectWebSocket.ts
@@ -1,0 +1,71 @@
+'use client';
+import SockJS from 'sockjs-client';
+import { Client, IMessage } from '@stomp/stompjs';
+import { useRef } from 'react';
+import { Room } from '../types/stomp';
+
+const BASE_WEBSOCKET_URL = process.env.NEXT_PUBLIC_WEBSOCKET_URL;
+
+export function useConnectWebSocket(token: string) {
+  const stompRef = useRef<Client | null>(null);
+
+  if (stompRef.current) return;
+  const socket = new SockJS(`${BASE_WEBSOCKET_URL}/ws?token=${encodeURIComponent(token)}`);
+
+  const client = new Client({
+    webSocketFactory: () => socket,
+    reconnectDelay: 5000,
+    debug: () => {},
+  });
+
+  client.onConnect = () => {
+    const roomReceiptId = 'sub-chatrooms';
+
+    // 채팅방 목록 구독
+    client.subscribe(
+      '/user/queue/chatrooms',
+      (msg: IMessage) => {
+        console.log('채팅방:', JSON.parse(msg.body));
+
+        try {
+          const list = JSON.parse(msg.body);
+          localStorage.setItem(
+            'chatRooms',
+            JSON.stringify(list.sort((a: Room, b: Room) => Number(a.roomId) - Number(b.roomId)))
+          );
+        } catch (e) {
+          console.error('채팅방 목록 파싱 오류', e);
+        }
+      },
+      { receipt: roomReceiptId }
+    );
+
+    client.publish({ destination: '/chat/enter', body: '선향' });
+
+    // //채팅방 목록 변경 구독 (업데이트 시 오름차순 정렬 유지)
+    // client.subscribe('/topic/chatrooms', (msg: IMessage) => {
+    //   console.log(JSON.parse(msg.body));
+    //   try {
+    //     const update = JSON.parse(msg.body);
+    //     setRooms((prev) => {
+    //       if (!prev) return;
+    //       const exists = prev.find((r) => r.roomId === update.roomId);
+    //       if (update.eventType === 'DELETE') {
+    //         return prev.filter((r) => r.roomId !== update.roomId);
+    //       } else if (exists) {
+    //         return prev.map((r) => (r.roomId === update.roomId ? update : r));
+    //       } else {
+    //         return [...prev, update].sort((a, b) => Number(a.roomId) - Number(b.roomId));
+    //       }
+    //     });
+    //   } catch (e) {
+    //     console.error('방 변경 처리 오류', e);
+    //   }
+    // });
+  };
+  stompRef.current = client;
+  client.activate();
+  return {
+    stompRef,
+  };
+}

--- a/src/features/chat/index.ts
+++ b/src/features/chat/index.ts
@@ -1,0 +1,2 @@
+export { default as ChatFooterNavigation } from './ui/ChatFooterNavigation';
+export { default as ChatTriggerButton } from './ui/ChatTriggerButton';

--- a/src/features/chat/types/stomp.ts
+++ b/src/features/chat/types/stomp.ts
@@ -1,0 +1,8 @@
+export interface Room {
+  roomId: number;
+  title: string;
+  headCount: number;
+  eventType: 'GET';
+}
+
+export type StompInitialRoomsType = Room[];

--- a/src/features/chat/ui/ChatFooterNavigation.tsx
+++ b/src/features/chat/ui/ChatFooterNavigation.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function ChatFooterNavigation() {
+  return (
+    <div className="fixed  w-full bottom-0">
+      <div className="flex w-full justify-around">
+        <Link href={'/'}>홈</Link>
+        <Link href={'/'}>채팅</Link>
+        <Link href={'/'}>설정</Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 사항

- ChatPage 들어갈때 웹소켓 연결
- websocket 에서 채팅방 목록 구독
- 구독후 받은 room 메시지 (rooms)를 일단 로컬스토리지에 저장시켰습니다.
- 현재는 임의의 토큰을 하드코딩하여 테스트한 상황이라 배포환경에서는 작동을 안합니다! 스토리지에 담아서 그걸 가져와서 사용하게 하려다가 pr 크기가 커질것을 염려하여 해당 pr을 중단점으로 가져가려 합니다

<br>

## ❗️ 전달 사항
pnpm i 하세요

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a chat room list display, showing available chat rooms or a message if none exist.
  - Added a persistent WebSocket connection for real-time chat room updates.
  - Implemented a fixed footer navigation bar with links for Home, Chat, and Settings in the chat dialog.
- **Chores**
  - Updated repository settings to ignore the backup directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->