### PR TITLE
refactoring : discussion 페이지 네이션, 정렬

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/page.tsx
@@ -28,8 +28,6 @@ export default async function HomePage() {
   return (
     <main className="w-full h-full py-20 bg-background text-white">
       <ChatDialogOpenButton />
-      {/* <button onClick={handleLogout}>로그아웃</button> */}
-
       <section className="text-center container mx-auto px-4">
         <div className="mb-8 flex items-center flex-col gap-6">
           <Image src="/icons/code.svg" alt="메인페이지 로고" width={80} height={80} />

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
@@ -18,7 +18,7 @@ export default async function ProblemPage({ params, searchParams }: IProblemPage
   }
 
   return (
-    <div className="w-full h-full">
+    <div className="w-full h-full overflow-scroll">
       {!isDiscussion ? (
         <DetailProblem detailProblem={detailProblem} />
       ) : (

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/layout.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/layout.tsx
@@ -12,7 +12,7 @@ export default async function ProblemPageLayout({
   const problemId = (await params).problemId;
 
   return (
-    <main className="flex pt-20 h-full gap-5">
+    <main className="flex pt-20 h-full gap-5 pb-20">
       <menu className="flex-1 flex flex-col gap-[29px]">
         <TabsToggle problemId={problemId} />
         {tabs}

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -3,6 +3,7 @@ export const PATHS = {
   SIGNUP: '/signup',
 
   PROBLEMS: '/problems',
+  MYPAGE: '/mypage',
   RANK: '/rank',
   CHAT: {
     SEARCHPARAMS_ID: 'room-id',

--- a/src/entities/discussions/discussions/model/query/discussion.query.type.ts
+++ b/src/entities/discussions/discussions/model/query/discussion.query.type.ts
@@ -1,21 +1,14 @@
 import { TVoteStatus } from '@/entities/discussions/vote/model/vote.mutation.type';
 import { IUserInfo } from '@/shared/types/auth';
+import { IPageAble } from '@/shared/types/pagenation';
+
+/**토론글 sort */
+export type sortType = '최신순' | '인기순' | '추천 많은순';
 
 /**토론글 get 요청시, 리스폰스(res.data.result) 로 받는 인터페이스  */
 export interface IDiscussionResponse {
   content: IDiscussionContentResponse[];
-  pageable: {
-    pageNumber: number;
-    pageSize: number;
-    sort: {
-      empty: boolean;
-      sorted: boolean;
-      unsorted: boolean;
-    };
-    offset: number;
-    paged: boolean;
-    unpaged: boolean;
-  };
+  pageable: IPageAble;
   totalElements: number;
   totalPages: number;
   last: boolean;

--- a/src/entities/discussions/discussions/model/query/discussions.query.ts
+++ b/src/entities/discussions/discussions/model/query/discussions.query.ts
@@ -2,31 +2,43 @@
 import ApiHelper from '@/api/client/api';
 import { getProblemIdPath } from '@/api/constants/api.constants';
 import { ProblemId } from '@/shared';
-import { useQuery } from '@tanstack/react-query';
-import { IDiscussionResponse } from './discussion.query.type';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { IDiscussionResponse, sortType } from './discussion.query.type';
 
-//토론 불러오기
-export const useDiscussionsQuery = (
+const formattedSort: Record<sortType, string> = {
+  인기순: 'best',
+  최신순: 'latest',
+  '추천 많은순': 'upvote',
+};
+
+export const useInfiniteDiscussionsQuery = (
   problemId: ProblemId,
-  pageable: { page: string; size: string; sort: string }
+  pageable: { page: string; size: string; sort: sortType }
 ) => {
-  const { page = '0', size = '8', sort } = pageable;
   const path = getProblemIdPath(problemId, 'discussions');
+  const { size = '8', sort } = pageable;
 
-  const formattedSort = sort === '최신순' ? 'latest' : 'best';
-
-  return useQuery({
-    queryKey: ['discussions', problemId, page, size, sort],
-    queryFn: async () => {
+  return useInfiniteQuery({
+    queryKey: ['infinite-discussions', problemId, size, formattedSort[sort]],
+    queryFn: async ({ pageParam }) => {
       try {
         const res = await ApiHelper.get<IDiscussionResponse>(`${path}`, {
-          params: { page, size, sort: formattedSort },
+          params: {
+            sortBy: formattedSort[sort],
+            page: String(pageParam),
+            size,
+            sort: formattedSort[sort],
+          },
         });
-        return res.data.result.content;
+        return res.data.result;
       } catch {
         console.error('토론 목록을 불러오는데 실패했습니다.');
-        return [];
+        return { content: [], last: true };
       }
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.last ? undefined : allPages.length;
     },
     staleTime: 1000 * 60 * 3,
   });

--- a/src/entities/discussions/discussions/model/query/discussions.query.ts
+++ b/src/entities/discussions/discussions/model/query/discussions.query.ts
@@ -6,16 +6,21 @@ import { useQuery } from '@tanstack/react-query';
 import { IDiscussionResponse } from './discussion.query.type';
 
 //토론 불러오기
-export const useDiscussionsQuery = (problemId: ProblemId) => {
-  const queryParams = {};
+export const useDiscussionsQuery = (
+  problemId: ProblemId,
+  pageable: { page: string; size: string; sort: string }
+) => {
+  const { page = '0', size = '8', sort } = pageable;
   const path = getProblemIdPath(problemId, 'discussions');
 
+  const formattedSort = sort === '최신순' ? 'latest' : 'best';
+
   return useQuery({
-    queryKey: ['discussions', problemId],
+    queryKey: ['discussions', problemId, page, size, sort],
     queryFn: async () => {
       try {
         const res = await ApiHelper.get<IDiscussionResponse>(`${path}`, {
-          params: queryParams,
+          params: { page, size, sort: formattedSort },
         });
         return res.data.result.content;
       } catch {

--- a/src/entities/discussions/index.ts
+++ b/src/entities/discussions/index.ts
@@ -1,5 +1,5 @@
 /**discussions */
-export { useDiscussionsQuery } from './discussions/model/query/discussions.query';
+export { useInfiniteDiscussionsQuery } from './discussions/model/query/discussions.query';
 export { useCreateDiscussionContent } from './discussions/model/mutation/discussions.mutations';
 export { useEditDiscussionContent } from './discussions/model/mutation/discussions.mutations';
 export { useDeleteDiscussionContent } from './discussions/model/mutation/discussions.mutations';

--- a/src/features/discussions/DiscussionFooter.tsx
+++ b/src/features/discussions/DiscussionFooter.tsx
@@ -19,7 +19,7 @@ interface IDiscussionFooterProps {
 export default function DiscussionFooter({ ...props }: IDiscussionFooterProps) {
   const { problemId, replyId, replyCount, content, onDelete, onEdit, setChildRepliesOpen } = props;
   return (
-    <div className="flex items-center gap-2 ">
+    <div className="flex items-center gap-2">
       <Vote problemId={problemId} content={content} replyId={replyId} />
       {replyCount !== undefined && (
         <ShowChildReplies onClick={() => setChildRepliesOpen?.()} replyCount={replyCount} />

--- a/src/features/discussions/disussions/ui/Discussion.tsx
+++ b/src/features/discussions/disussions/ui/Discussion.tsx
@@ -5,7 +5,7 @@ import { useDeleteDiscussionContent } from '@/entities/discussions';
 import Replies from '../../reply/ui/Replies';
 import { TDiscussionContentMutationResponse } from '@/entities/discussions/discussions/model/mutation/discussions.types';
 import { LANGUAGE } from '@/shared/types/problem.type';
-import UserImage from '@/shared/ui/user/UserImage';
+import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
 
 interface IDiscussionContentProps {

--- a/src/features/discussions/disussions/ui/Discussion.tsx
+++ b/src/features/discussions/disussions/ui/Discussion.tsx
@@ -25,32 +25,34 @@ export default function Discussion({ discussion }: IDiscussionContentProps) {
 
   return (
     <div className="bg-secondary-background rounded-[10px] p-6 shadow-lg w-full flex flex-col">
-      {isEdit ? (
-        <DiscussionForm
-          problemId={String(problemId)}
-          mode="edit"
-          discussion={discussion}
-          changeEditMode={(status) => setIsEdit(status)}
-        />
-      ) : (
-        <div className="w-full flex flex-col gap-2">
-          <div className="flex items-center gap-3">
-            <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
-            <span className="text-[#888] text-sm ml-2">{LANGUAGE[languageId]}</span>
-          </div>
-          <p className="text-[#ccc] leading-relaxed">{content}</p>
-          <DiscussionFooter
-            content={discussion}
-            problemId={String(problemId)}
-            setChildRepliesOpen={() => {
-              setIsRepliesOpen((prev) => !prev);
-            }}
-            replyCount={replyCount}
-            onDelete={() => deleteMutate()}
-            onEdit={() => setIsEdit(true)}
-          />
+      <div className="w-full flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
+          <span className="text-[#888] text-sm ml-2">{LANGUAGE[languageId]}</span>
         </div>
-      )}
+        {!isEdit ? (
+          <>
+            <p className="text-[#ccc] leading-relaxed">{content}</p>
+            <DiscussionFooter
+              content={discussion}
+              problemId={String(problemId)}
+              setChildRepliesOpen={() => {
+                setIsRepliesOpen((prev) => !prev);
+              }}
+              replyCount={replyCount}
+              onDelete={() => deleteMutate()}
+              onEdit={() => setIsEdit(true)}
+            />
+          </>
+        ) : (
+          <DiscussionForm
+            problemId={String(problemId)}
+            mode="edit"
+            discussion={discussion}
+            changeEditMode={(status) => setIsEdit(status)}
+          />
+        )}
+      </div>
       {isRepliesOpen && <Replies problemId={String(problemId)} discussionId={discussionId} />}
     </div>
   );

--- a/src/features/discussions/disussions/ui/Discussion.tsx
+++ b/src/features/discussions/disussions/ui/Discussion.tsx
@@ -5,8 +5,8 @@ import { useDeleteDiscussionContent } from '@/entities/discussions';
 import Replies from '../../reply/ui/Replies';
 import { TDiscussionContentMutationResponse } from '@/entities/discussions/discussions/model/mutation/discussions.types';
 import { LANGUAGE } from '@/shared/types/problem.type';
-import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
+import UserProfile from '@/shared/ui/userProfile';
 
 interface IDiscussionContentProps {
   discussion: TDiscussionContentMutationResponse;
@@ -33,15 +33,12 @@ export default function Discussion({ discussion }: IDiscussionContentProps) {
           changeEditMode={(status) => setIsEdit(status)}
         />
       ) : (
-        <div className="w-full mb-4">
+        <div className="w-full flex flex-col gap-2">
           <div className="flex items-center gap-3">
-            <UserImage className="size-8" profileImageUrl={userInfo.profileImageUrl} />
-            <>
-              <span className="font-medium text-[#00d084]">{userInfo.nickname}</span>
-              <span className="text-[#888] text-sm ml-2">{LANGUAGE[languageId]}</span>
-            </>
+            <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
+            <span className="text-[#888] text-sm ml-2">{LANGUAGE[languageId]}</span>
           </div>
-          <p className="text-[#ccc] mb-4 leading-relaxed">{content}</p>
+          <p className="text-[#ccc] leading-relaxed">{content}</p>
           <DiscussionFooter
             content={discussion}
             problemId={String(problemId)}

--- a/src/features/discussions/disussions/ui/DiscussionForm.tsx
+++ b/src/features/discussions/disussions/ui/DiscussionForm.tsx
@@ -12,6 +12,7 @@ import { INITIAL_LANG, ProblemId, ProblemLanguageType } from '@/shared';
 import { LANGUAGE_SELECTOR_OPTIONS } from '@/shared/lib/codemirror';
 import { LANGUAGE, LANGUAGE_ID } from '@/shared/types/problem.type';
 import { OptionType, Select } from '@/shared/ui/select/Select';
+import clsx from 'clsx';
 import { ChangeEvent, useState } from 'react';
 
 interface ICreateDiscussionInputProps {
@@ -62,7 +63,7 @@ export default function DiscussionForm({
   };
 
   return (
-    <div className="relative">
+    <div className="relative flex flex-col gap-3">
       <Select
         title="언어 선택"
         value={currentLanguage}
@@ -70,15 +71,25 @@ export default function DiscussionForm({
         setValue={(value) => selectLanguage(value)}
       />
       <textarea
-        className="border-1 w-full h-[100px]"
+        className={clsx(
+          'w-full h-[100px] resize-none',
+          mode === 'create' ? 'border-1 ' : 'border-none'
+        )}
         value={contentForm.content}
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
           setContentForm((prev) => ({ ...prev, content: e.target.value }))
         }
       />
-      <Button className="absolute right-4 top-5" onClick={() => submitDiscussionForm()}>
-        {buttonText}
-      </Button>
+      <div className="absolute right-4 top-[calc(50%-5px)] flex gap-2">
+        <Button className="" onClick={() => submitDiscussionForm()}>
+          {buttonText}
+        </Button>
+        {mode === 'edit' && (
+          <Button className="" onClick={() => changeEditMode?.(false)}>
+            취소
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -1,28 +1,52 @@
 'use client';
 import { ProblemId } from '@/shared';
 import Discussion from './Discussion';
-import { Spinner } from '@/shared/ui/loading-indicators';
+import { BouncingDots, Spinner } from '@/shared/ui/loading-indicators';
 import DiscussionForm from './DiscussionForm';
-import { useDiscussionsQuery } from '@/entities/discussions';
 import { Select } from '@/shared/ui/select/Select';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { sortType } from '@/entities/discussions/discussions/model/query/discussion.query.type';
+import { useInfiniteDiscussionsQuery } from '@/entities/discussions/discussions/model/query/discussions.query';
 
 interface IDiscussionProps {
   problemId: ProblemId;
 }
+
 interface IPageAble {
   page: string;
   size: string;
-  sort: string;
+  sort: sortType;
 }
 export default function Discussions({ problemId }: IDiscussionProps) {
-  const [pageAble, setPageAble] = useState<IPageAble>({ page: '0', size: '8', sort: '최신순' });
-  const { data: discussions, isPending } = useDiscussionsQuery(problemId, pageAble);
+  const [pageAble, setPageAble] = useState<IPageAble>({ page: '0', size: '8', sort: '인기순' });
+  const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteDiscussionsQuery(problemId, pageAble);
+  const discussions = data?.pages.flatMap((page) => page.content);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
 
   const sortOptions = [
+    { label: '인기순', value: '인기순' },
     { label: '최신순', value: '최신순' },
     { label: '추천 많은 순', value: '추천 많은 순' },
   ];
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasNextPage) {
+        fetchNextPage();
+      }
+    });
+
+    if (loaderRef.current) {
+      observer.observe(loaderRef.current);
+    }
+
+    return () => {
+      if (loaderRef.current) {
+        observer.disconnect();
+      }
+    };
+  }, [fetchNextPage, hasNextPage]);
 
   if (isPending) {
     return (
@@ -31,9 +55,8 @@ export default function Discussions({ problemId }: IDiscussionProps) {
       </div>
     );
   }
-
   return (
-    <div className="flex flex-col gap-[10px]">
+    <div className="flex flex-col gap-[10px] w-full h-full">
       <DiscussionForm problemId={problemId} mode="create" />
       <div className="flex items-center justify-center">
         {!discussions ? (
@@ -44,15 +67,27 @@ export default function Discussions({ problemId }: IDiscussionProps) {
               option={sortOptions}
               title="정렬"
               value={pageAble.sort}
-              setValue={(value) => setPageAble((prev) => ({ ...prev, sort: value }))}
+              setValue={(value) => {
+                const typedValue = value as sortType;
+                setPageAble((prev) => ({ ...prev, sort: typedValue }));
+              }}
             />
             {discussions.length < 1 ? (
-              <p>아직 토론이 없습니다.</p>
+              <div className="flex justify-center text-[#ccc] mt-3">
+                아직 해당문제의 토론글이 없습니다.
+              </div>
             ) : (
-              <div className="space-y-4 transition-transform duration-300 transform translate-y-4 w-full">
-                {discussions.map((content) => {
-                  return <Discussion discussion={content} key={content.discussionId} />;
-                })}
+              <div className="space-y-4 transition-transform duration-300 transform translate-y-4 w-full ">
+                {discussions &&
+                  discussions.map((content) => {
+                    return <Discussion discussion={content} key={content.discussionId} />;
+                  })}
+                <div ref={loaderRef} style={{ height: 1 }} />
+                {isFetchingNextPage && (
+                  <div className="flex justify-center mt-3">
+                    <BouncingDots />
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -6,7 +6,7 @@ import DiscussionForm from './DiscussionForm';
 import { Select } from '@/shared/ui/select/Select';
 import { useEffect, useRef, useState } from 'react';
 import { sortType } from '@/entities/discussions/discussions/model/query/discussion.query.type';
-import { useInfiniteDiscussionsQuery } from '@/entities/discussions/discussions/model/query/discussions.query';
+import { useInfiniteDiscussionsQuery } from '@/entities/discussions';
 
 interface IDiscussionProps {
   problemId: ProblemId;
@@ -19,8 +19,10 @@ interface IPageAble {
 }
 export default function Discussions({ problemId }: IDiscussionProps) {
   const [pageAble, setPageAble] = useState<IPageAble>({ page: '0', size: '8', sort: '인기순' });
+
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteDiscussionsQuery(problemId, pageAble);
+
   const discussions = data?.pages.flatMap((page) => page.content);
   const loaderRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -4,13 +4,25 @@ import Discussion from './Discussion';
 import { Spinner } from '@/shared/ui/loading-indicators';
 import DiscussionForm from './DiscussionForm';
 import { useDiscussionsQuery } from '@/entities/discussions';
+import { Select } from '@/shared/ui/select/Select';
+import { useState } from 'react';
 
 interface IDiscussionProps {
   problemId: ProblemId;
 }
-
+interface IPageAble {
+  page: string;
+  size: string;
+  sort: string;
+}
 export default function Discussions({ problemId }: IDiscussionProps) {
-  const { data: discussions, isPending } = useDiscussionsQuery(problemId);
+  const [pageAble, setPageAble] = useState<IPageAble>({ page: '0', size: '8', sort: '최신순' });
+  const { data: discussions, isPending } = useDiscussionsQuery(problemId, pageAble);
+
+  const sortOptions = [
+    { label: '최신순', value: '최신순' },
+    { label: '추천 많은 순', value: '추천 많은 순' },
+  ];
 
   if (isPending) {
     return (
@@ -27,7 +39,13 @@ export default function Discussions({ problemId }: IDiscussionProps) {
         {!discussions ? (
           <p>토론 목록을 불러오는데 실패했습니다.</p>
         ) : (
-          <>
+          <div className="flex flex-col w-full">
+            <Select
+              option={sortOptions}
+              title="정렬"
+              value={pageAble.sort}
+              setValue={(value) => setPageAble((prev) => ({ ...prev, sort: value }))}
+            />
             {discussions.length < 1 ? (
               <p>아직 토론이 없습니다.</p>
             ) : (
@@ -37,7 +55,7 @@ export default function Discussions({ problemId }: IDiscussionProps) {
                 })}
               </div>
             )}
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/src/features/discussions/reply/ui/NestedReply.tsx
+++ b/src/features/discussions/reply/ui/NestedReply.tsx
@@ -2,7 +2,7 @@ import { ProblemId } from '@/shared';
 import { useState } from 'react';
 import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
-import UserImage from '@/shared/ui/user/UserImage';
+import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
 
 interface INestedReplyProps {

--- a/src/features/discussions/reply/ui/NestedReply.tsx
+++ b/src/features/discussions/reply/ui/NestedReply.tsx
@@ -4,6 +4,7 @@ import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
 import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
+import UserProfile from '@/shared/ui/userProfile';
 
 interface INestedReplyProps {
   nestedReply: IReply;
@@ -23,13 +24,11 @@ export default function NestedReply({ nestedReply, problemId }: INestedReplyProp
     <div className="flex flex-col">
       <div>
         {!isEdit ? (
-          <div className="bg-background rounded-[14px] p-3">
-            <div className="flex items-center gap-2 mb-2">
-              <UserImage profileImageUrl={nestedReply.userInfo.profileImageUrl} />
-              <span className="font-medium text-secondary text-xs">
-                {nestedReply.userInfo.nickname}
-              </span>
-            </div>
+          <div className="bg-background rounded-[14px] p-3 flex flex-col gap-2">
+            <UserProfile
+              profileImageUrl={nestedReply.userInfo.profileImageUrl}
+              nickname={nestedReply.userInfo.nickname}
+            />
             <p className="text-[#ccc] text-xs mb-2">{nestedReply.content}</p>
             <DiscussionFooter
               content={nestedReply}

--- a/src/features/discussions/reply/ui/NestedReply.tsx
+++ b/src/features/discussions/reply/ui/NestedReply.tsx
@@ -2,7 +2,6 @@ import { ProblemId } from '@/shared';
 import { useState } from 'react';
 import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
-import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
 import UserProfile from '@/shared/ui/userProfile';
 
@@ -23,31 +22,33 @@ export default function NestedReply({ nestedReply, problemId }: INestedReplyProp
   return (
     <div className="flex flex-col">
       <div>
-        {!isEdit ? (
-          <div className="bg-background rounded-[14px] p-3 flex flex-col gap-2">
-            <UserProfile
-              profileImageUrl={nestedReply.userInfo.profileImageUrl}
-              nickname={nestedReply.userInfo.nickname}
-            />
-            <p className="text-[#ccc] text-xs mb-2">{nestedReply.content}</p>
-            <DiscussionFooter
-              content={nestedReply}
-              problemId={problemId}
-              replyId={nestedReply.replyId}
-              onDelete={() => remove()}
-              onEdit={() => setIsEdit(true)}
-            />
-          </div>
-        ) : (
-          <ReplyForm
-            problemId={problemId}
-            discussionId={discussionId}
-            mode="create"
-            parentReplyId={parentReplyId}
-            initialValue={nestedReply.content}
-            onClick={() => setIsEdit(true)}
+        <div className="bg-background rounded-[14px] p-3 flex flex-col gap-2">
+          <UserProfile
+            profileImageUrl={nestedReply.userInfo.profileImageUrl}
+            nickname={nestedReply.userInfo.nickname}
           />
-        )}
+          {!isEdit ? (
+            <>
+              <p className="text-[#ccc] text-xs mb-2">{nestedReply.content}</p>
+              <DiscussionFooter
+                content={nestedReply}
+                problemId={problemId}
+                replyId={nestedReply.replyId}
+                onDelete={() => remove()}
+                onEdit={() => setIsEdit(true)}
+              />
+            </>
+          ) : (
+            <ReplyForm
+              problemId={problemId}
+              discussionId={discussionId}
+              mode="edit"
+              parentReplyId={parentReplyId}
+              initialValue={nestedReply.content}
+              onClick={() => setIsEdit(false)}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/features/discussions/reply/ui/Replies.tsx
+++ b/src/features/discussions/reply/ui/Replies.tsx
@@ -25,7 +25,7 @@ export default function Replies({ problemId, discussionId }: RepliesProps) {
     );
   }
   return (
-    <div className="w-full h-full relative border-t border-primary pt-4 space-y-4">
+    <div className="w-full h-full relative border-t border-primary pt-4 space-y-4 mt-4">
       {!token && <ProtectedBlurBox />}
       <div className="ml-4 flex flex-col gap-4">
         <ReplyForm

--- a/src/features/discussions/reply/ui/Reply.tsx
+++ b/src/features/discussions/reply/ui/Reply.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import NestedReplies from './NestedReplies';
 import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
-import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
 import UserProfile from '@/shared/ui/userProfile';
 
@@ -26,42 +25,43 @@ export default function Reply({ reply, problemId }: IReplyProps) {
   return (
     <div className="flex flex-col">
       <div>
-        {!isEdit ? (
-          <div className="flex flex-col gap-2">
-            <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
-            <p className="text-[#ccc] text-sm ml-8">{content}</p>
-            <DiscussionFooter
-              content={reply}
+        <div className="flex flex-col gap-2">
+          <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
+          {!isEdit ? (
+            <>
+              <p className="text-[#ccc] text-sm ml-8">{content}</p>
+              <DiscussionFooter
+                content={reply}
+                problemId={problemId}
+                replyId={replyId}
+                setChildRepliesOpen={() => {
+                  setIsNestedRepliesOpen((prev) => !prev);
+                }}
+                replyCount={childReplyCount}
+                onDelete={() => remove()}
+                onEdit={() => setIsEdit(true)}
+              />
+              <div className="pl-8">
+                {isNestedRepliesOpen && (
+                  <NestedReplies
+                    problemId={problemId}
+                    discussionId={discussionId}
+                    parentReplyId={replyId}
+                  />
+                )}
+              </div>
+            </>
+          ) : (
+            <ReplyForm
               problemId={problemId}
-              replyId={replyId}
-              setChildRepliesOpen={() => {
-                setIsNestedRepliesOpen((prev) => !prev);
-              }}
-              replyCount={childReplyCount}
-              onDelete={() => remove()}
-              onEdit={() => setIsEdit(true)}
+              discussionId={discussionId}
+              parentReplyId={null}
+              mode="edit"
+              initialValue={content}
+              onClick={() => setIsEdit(false)}
             />
-
-            <div className="pl-8">
-              {isNestedRepliesOpen && (
-                <NestedReplies
-                  problemId={problemId}
-                  discussionId={discussionId}
-                  parentReplyId={replyId}
-                />
-              )}
-            </div>
-          </div>
-        ) : (
-          <ReplyForm
-            problemId={problemId}
-            discussionId={discussionId}
-            parentReplyId={null}
-            mode="create"
-            initialValue={content}
-            onClick={() => setIsEdit(false)}
-          />
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/features/discussions/reply/ui/Reply.tsx
+++ b/src/features/discussions/reply/ui/Reply.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import NestedReplies from './NestedReplies';
 import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
-import UserImage from '@/shared/ui/user/UserImage';
+import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
 
 interface IReplyProps {

--- a/src/features/discussions/reply/ui/Reply.tsx
+++ b/src/features/discussions/reply/ui/Reply.tsx
@@ -5,6 +5,7 @@ import ReplyForm from './ReplyForm';
 import { IReply, useDeleteReplyMutation } from '@/entities/discussions';
 import UserImage from '@/shared/ui/userProfile/UserImage';
 import DiscussionFooter from '../../DiscussionFooter';
+import UserProfile from '@/shared/ui/userProfile';
 
 interface IReplyProps {
   reply: IReply;
@@ -26,12 +27,9 @@ export default function Reply({ reply, problemId }: IReplyProps) {
     <div className="flex flex-col">
       <div>
         {!isEdit ? (
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <UserImage profileImageUrl={userInfo.profileImageUrl} />
-              <span className="font-medium text-secondary text-sm">{userInfo.nickname}</span>
-            </div>
-            <p className="text-[#ccc] text-sm mb-2 ml-8">{content}</p>
+          <div className="flex flex-col gap-2">
+            <UserProfile profileImageUrl={userInfo.profileImageUrl} nickname={userInfo.nickname} />
+            <p className="text-[#ccc] text-sm ml-8">{content}</p>
             <DiscussionFooter
               content={reply}
               problemId={problemId}

--- a/src/features/discussions/reply/ui/ReplyForm.tsx
+++ b/src/features/discussions/reply/ui/ReplyForm.tsx
@@ -36,16 +36,28 @@ export default function ReplyForm({
         placeholder="댓글을 작성하세요..."
         className="w-full p-2 bg-background border-border_primary rounded-[14px] resize-none min-h-[40px] text-sm"
       />
-      <Button
-        size="sm"
-        className="bg-primary hover:bg-primary/80 rounded-[10px] px-4 py-2"
-        onClick={() => {
-          submitReply(mode);
-          onClick?.();
-        }}
-      >
-        {mode === 'create' ? <Send className="w-4 h-4" /> : '완료'}
-      </Button>
+      <>
+        <Button
+          size="sm"
+          className="bg-primary hover:bg-primary/80 rounded-[10px] px-4 py-2"
+          onClick={() => {
+            submitReply(mode);
+            onClick?.();
+          }}
+        >
+          {mode === 'create' ? <Send className="w-4 h-4" /> : '완료'}
+        </Button>
+        {mode === 'edit' && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="rounded-[10px] px-4 py-2"
+            onClick={onClick}
+          >
+            취소
+          </Button>
+        )}
+      </>
     </div>
   );
 }

--- a/src/shared/types/pagenation.ts
+++ b/src/shared/types/pagenation.ts
@@ -1,0 +1,13 @@
+/**pagination 을 위한 타입  */
+export interface IPageAble {
+  pageNumber: number;
+  pageSize: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}

--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -28,7 +28,7 @@ interface PropsType extends HTMLAttributes<HTMLDivElement> {
   setValue?: (value: string) => void;
 
   /** 현재 선택된 값 */
-  value: string;
+  value: string | ReactNode;
 
   /** 컴포넌트 사이즈 (기본값: 'md') */
   size?: 'sm' | 'md' | 'lg';
@@ -46,7 +46,7 @@ interface PropsType extends HTMLAttributes<HTMLDivElement> {
   title: string;
   className?: string;
   setValue?: (value: string) => void;
-  value: string;
+  value: string | ReactNode;
   size?: 'sm' | 'md' | 'lg';
   type?: 'setValue' | 'router' | 'api';
   entireOption?: boolean;

--- a/src/shared/ui/userProfile/UserImage.tsx
+++ b/src/shared/ui/userProfile/UserImage.tsx
@@ -9,7 +9,7 @@ export default function UserImage({ profileImageUrl, className = 'size-8' }: IUs
   return (
     <div className={clsx('relative', className)}>
       <img
-        src={profileImageUrl ?? '/icons/user.svg'}
+        src={profileImageUrl || '/icons/user.svg'}
         alt="유저 이미지"
         className="rounded-full object-cover z-10 "
       />

--- a/src/shared/ui/userProfile/index.tsx
+++ b/src/shared/ui/userProfile/index.tsx
@@ -1,7 +1,7 @@
 import UserImage from './UserImage';
 
 interface IUserProfileProps {
-  profileImageUrl: string | undefined;
+  profileImageUrl: string | undefined | null;
   nickname: string | undefined;
 }
 export default function UserProfile({ profileImageUrl, nickname }: IUserProfileProps) {

--- a/src/shared/ui/userProfile/index.tsx
+++ b/src/shared/ui/userProfile/index.tsx
@@ -1,0 +1,14 @@
+import UserImage from './UserImage';
+
+interface IUserProfileProps {
+  profileImageUrl: string | undefined;
+  nickname: string | undefined;
+}
+export default function UserProfile({ profileImageUrl, nickname }: IUserProfileProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <UserImage profileImageUrl={profileImageUrl || ''} />
+      <span className="font-medium text-secondary text-sm">{nickname || ''}</span>
+    </div>
+  );
+}

--- a/src/widgets/NavigationBar/ui/AuthActions.tsx
+++ b/src/widgets/NavigationBar/ui/AuthActions.tsx
@@ -4,35 +4,52 @@ import LinkedButton from '@/shared/ui/linkedButton';
 import { AUTH_ACTIONS_OPTIONS, NAVIGATE_ATTRIBUTE } from '../navigateAttribute';
 import { Select } from '@/shared/ui/select/Select';
 import useAccessToken from '@/shared/hooks/useAuthToken';
+import { useEffect, useState } from 'react';
+import { useMyInfoQuery } from '@/entities/mypage/model/query';
+import UserProfile from '@/shared/ui/userProfile';
+import { useRouter } from 'next/navigation';
+import { PATHS } from '@/constants/paths';
+import { useLogoutMutation } from '@/entities/auth/model/mutation/auth.mutation';
+
+interface IUserInfo {
+  profileImage: string;
+  nickname: string;
+}
 
 export default function AuthActions() {
+  const [userInfo, setUserInfo] = useState<IUserInfo | null>(null);
   const accessToken = useAccessToken();
+  const { data } = useMyInfoQuery();
+  const router = useRouter();
+  const { mutateAsync } = useLogoutMutation();
+
+  useEffect(() => {
+    setUserInfo({
+      profileImage: data?.data.result.profileImageUrl || '',
+      nickname: data?.data.result.nickname || '',
+    });
+  }, [data?.data.result]);
+
+  const selectOption = (value: string) => {
+    if (value === 'mypage') return router.push(PATHS.MYPAGE);
+    if (value === 'logout') return mutateAsync();
+  };
 
   return (
     <div className="flex items-center space-x-4">
       {accessToken ? (
         <Select
           option={AUTH_ACTIONS_OPTIONS}
-          title="타이틀"
-          setValue={() => {}}
-          value="value"
+          title="사용자 메뉴"
+          setValue={(value) => {
+            selectOption(value);
+          }}
+          value={
+            <UserProfile profileImageUrl={userInfo?.profileImage} nickname={userInfo?.nickname} />
+          }
           className="text-white transition-all duration-200"
         />
       ) : (
-        /* <div>
-          <Button
-            variant="ghost"
-            className="text-white hover:text-secondary hover:bg-white/8 transition-all duration-200 hover:shadow-lg"
-          >
-            <Image src="/icons/user.svg" height={20} width={20} alt="유저 아이콘" />
-            계정
-            <p className="h-4 w-4 ml-2">\/</p>
-          </Button>
-        </div>
-        <ul className="bg-[#1a2332] border-gray-700 text-white hover:bg-white/8 hover:text-secondary">
-          <li>마이페이지</li>
-          <li>로그아웃</li>
-        </ul> */
         <>
           <LinkedButton props={NAVIGATE_ATTRIBUTE.signup} />
           <LinkedButton props={NAVIGATE_ATTRIBUTE.signin} />


### PR DESCRIPTION
## 🔎 작업 사항

- discussion 의 무한스크롤 페이지 네이션, 정렬 기능 추가했습니다.

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필(이미지, 닉네임) 컴포넌트 추가 및 내 정보 조회 기능 도입.
  * 토론 목록에 정렬 옵션 선택 및 무한 스크롤(인피니트 스크롤) 기능 추가.
  * 사용자 메뉴에서 프로필 정보와 로그아웃, 마이페이지 이동 기능 제공.

* **기능 개선**
  * 토론, 답글, 대댓글 컴포넌트에서 사용자 정보 표시 방식 개선 및 레이아웃 통일.
  * 토론 목록, 답글 영역 등 레이아웃 및 마진, 스크롤 등 UI 세부 개선.
  * Select 컴포넌트의 value 타입 확장(문자열 또는 ReactNode 지원).

* **버그 수정/스타일**
  * 불필요한 공백, 주석 버튼 등 UI 요소 정리.
  * 기본 이미지 처리 방식 개선(빈 값도 기본 이미지로 대체).

* **기타**
  * 정렬 타입, 페이징 인터페이스 등 타입 구조 추가 및 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->