### PR TITLE
fix : discussion

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
@@ -18,7 +18,7 @@ export default async function ProblemPage({ params, searchParams }: IProblemPage
   }
 
   return (
-    <div className="w-full h-full overflow-scroll">
+    <div className="w-full h-full overflow-y-scroll">
       {!isDiscussion ? (
         <DetailProblem detailProblem={detailProblem} />
       ) : (

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/@tabs/page.tsx
@@ -1,6 +1,7 @@
 import Discussions from '@/features/discussions/disussions/ui/Discussions';
 import { DetailProblem, getDetailProblem } from '@/entities/problem';
 import CollapsibleProblem from '@/entities/problem/ui/CollapsibleProblem';
+import { DiscussionsParamsProvider } from '@/features/discussions/disussions/model/Discussion.sort.context';
 
 interface IProblemPageProps {
   params: Promise<{ problemId: string }>;
@@ -24,7 +25,9 @@ export default async function ProblemPage({ params, searchParams }: IProblemPage
       ) : (
         <div className="flex flex-col gap-[10px]">
           <CollapsibleProblem detailProblem={detailProblem} />
-          <Discussions problemId={problemId} />
+          <DiscussionsParamsProvider>
+            <Discussions problemId={problemId} />
+          </DiscussionsParamsProvider>
         </div>
       )}
     </div>

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/layout.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/layout.tsx
@@ -12,7 +12,7 @@ export default async function ProblemPageLayout({
   const problemId = (await params).problemId;
 
   return (
-    <main className="flex pt-20 h-full gap-5 pb-20">
+    <main className="flex py-10 h-full gap-5 ">
       <menu className="flex-1 flex flex-col gap-[29px]">
         <TabsToggle problemId={problemId} />
         {tabs}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
         <QueryProvider>
           <div className="w-full h-full">
             <NavigationBar />
-            <div className="w-full h-full px-15">{children}</div>
+            <div className="w-full h-[calc(100vh-72px)] px-15">{children}</div>
           </div>
           <Toaster />
         </QueryProvider>

--- a/src/entities/discussions/discussions/model/mutation/discussions.mutations.ts
+++ b/src/entities/discussions/discussions/model/mutation/discussions.mutations.ts
@@ -6,11 +6,16 @@ import {
   IDiscussionContentMutationRequest,
   TDiscussionContentMutationResponse,
 } from './discussions.types';
+import { useDiscussionParams } from '@/features/discussions/disussions/model/Discussion.sort.context';
+import { paramsQueryKeys } from '@/shared/model/query/paramsQueryKey';
 
 /** 토론글 생성 뮤테이션 */
 export const useCreateDiscussionContent = (problemId: ProblemId) => {
   const path = getProblemIdPath(problemId, 'discussions');
   const queryClient = useQueryClient();
+  const { params } = useDiscussionParams();
+
+  const queryKey = paramsQueryKeys.key('infinite-discussions', problemId, params);
 
   return useMutation({
     mutationFn: async (params: IDiscussionContentMutationRequest) => {
@@ -18,7 +23,7 @@ export const useCreateDiscussionContent = (problemId: ProblemId) => {
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['discussions', problemId] });
+      queryClient.invalidateQueries({ queryKey: queryKey });
     },
   });
 };
@@ -28,6 +33,9 @@ export const useEditDiscussionContent = (problemId: ProblemId, discussionId: num
   const path = getProblemIdPath(problemId, 'discussions');
   const queryClient = useQueryClient();
 
+  const { params } = useDiscussionParams();
+
+  const queryKey = paramsQueryKeys.key('infinite-discussions', problemId, params);
   return useMutation({
     mutationFn: async (params: IDiscussionContentMutationRequest) => {
       const response = await ApiHelper.put<TDiscussionContentMutationResponse>(
@@ -37,7 +45,7 @@ export const useEditDiscussionContent = (problemId: ProblemId, discussionId: num
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['discussions', problemId] });
+      queryClient.invalidateQueries({ queryKey: queryKey });
     },
   });
 };
@@ -47,13 +55,17 @@ export const useDeleteDiscussionContent = (problemId: ProblemId, discussionId: n
   const path = getProblemIdPath(problemId, 'discussions');
   const queryClient = useQueryClient();
 
+  const { params } = useDiscussionParams();
+
+  const queryKey = paramsQueryKeys.key('infinite-discussions', problemId, params);
+
   return useMutation({
     mutationFn: async () => {
       const response = await ApiHelper.delete(`${path}/${discussionId}`);
       return response;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['discussions', problemId] });
+      queryClient.invalidateQueries({ queryKey: queryKey });
     },
   });
 };

--- a/src/entities/discussions/discussions/model/query/discussion.query.type.ts
+++ b/src/entities/discussions/discussions/model/query/discussion.query.type.ts
@@ -3,7 +3,7 @@ import { IUserInfo } from '@/shared/types/auth';
 import { IPageAble } from '@/shared/types/pagenation';
 
 /**토론글 sort */
-export type sortType = '최신순' | '인기순' | '추천 많은순';
+export type sortType = '최신순' | '인기순' | '추천순';
 
 /**토론글 get 요청시, 리스폰스(res.data.result) 로 받는 인터페이스  */
 export interface IDiscussionResponse {

--- a/src/entities/discussions/discussions/model/query/discussion.query.type.ts
+++ b/src/entities/discussions/discussions/model/query/discussion.query.type.ts
@@ -3,7 +3,6 @@ import { IUserInfo } from '@/shared/types/auth';
 import { IPageAble } from '@/shared/types/pagenation';
 
 /**토론글 sort */
-export type sortType = '최신순' | '인기순' | '추천순';
 
 /**토론글 get 요청시, 리스폰스(res.data.result) 로 받는 인터페이스  */
 export interface IDiscussionResponse {

--- a/src/entities/discussions/discussions/model/query/discussions.query.ts
+++ b/src/entities/discussions/discussions/model/query/discussions.query.ts
@@ -3,28 +3,25 @@ import ApiHelper from '@/api/client/api';
 import { getProblemIdPath } from '@/api/constants/api.constants';
 import { ProblemId } from '@/shared';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { IDiscussionResponse, sortType } from './discussion.query.type';
+import { IDiscussionResponse } from './discussion.query.type';
+import { formattedSort, paramsQueryKeys } from '@/shared/model/query/paramsQueryKey';
+import { useDiscussionParams } from '@/features/discussions/disussions/model/Discussion.sort.context';
 
-const formattedSort: Record<sortType, string> = {
-  인기순: 'best',
-  최신순: 'latest',
-  추천순: 'upvote',
-};
-
-export const useInfiniteDiscussionsQuery = (
-  problemId: ProblemId,
-  pageable: { page: string; size: string; sort: sortType }
-) => {
+export const useInfiniteDiscussionsQuery = (problemId: ProblemId) => {
   const path = getProblemIdPath(problemId, 'discussions');
-  const { size = '8', sort } = pageable;
+  const { params } = useDiscussionParams();
+
+  const { size = '8', sort, sortBy } = params;
+
+  const queryKey = paramsQueryKeys.key('infinite-discussions', problemId, params);
 
   return useInfiniteQuery({
-    queryKey: ['infinite-discussions', problemId, size, formattedSort[sort]],
+    queryKey: queryKey,
     queryFn: async ({ pageParam }) => {
       try {
         const res = await ApiHelper.get<IDiscussionResponse>(`${path}`, {
           params: {
-            sortBy: formattedSort[sort],
+            sortBy: formattedSort[sortBy],
             page: String(pageParam),
             size,
             sort: formattedSort[sort],

--- a/src/entities/discussions/discussions/model/query/discussions.query.ts
+++ b/src/entities/discussions/discussions/model/query/discussions.query.ts
@@ -8,7 +8,7 @@ import { IDiscussionResponse, sortType } from './discussion.query.type';
 const formattedSort: Record<sortType, string> = {
   인기순: 'best',
   최신순: 'latest',
-  '추천 많은순': 'upvote',
+  추천순: 'upvote',
 };
 
 export const useInfiniteDiscussionsQuery = (

--- a/src/features/discussions/disussions/model/Discussion.sort.context.tsx
+++ b/src/features/discussions/disussions/model/Discussion.sort.context.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { INITIAL_PARAMS, IParams } from '@/shared/model/query/paramsQueryKey';
+import { createContext, Dispatch, SetStateAction, useContext, useMemo, useState } from 'react';
+
+type Ctx = {
+  params: IParams;
+  setParams: Dispatch<SetStateAction<IParams>>;
+};
+
+const SortContext = createContext<Ctx | null>(null);
+
+export function DiscussionsParamsProvider({
+  initialParams = INITIAL_PARAMS,
+  children,
+}: {
+  initialParams?: IParams;
+  children: React.ReactNode;
+}) {
+  const [params, setParams] = useState<IParams>(initialParams);
+  const value = useMemo(() => ({ params, setParams }), [params]);
+  console.log(params);
+  return <SortContext.Provider value={value}>{children}</SortContext.Provider>;
+}
+export function useDiscussionParams() {
+  const ctx = useContext(SortContext);
+  if (!ctx) throw new Error('useDiscussionSort을  <DiscussionsSortProvider> 안에서 사용하세요');
+
+  return ctx;
+}

--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -4,24 +4,19 @@ import Discussion from './Discussion';
 import { BouncingDots, Spinner } from '@/shared/ui/loading-indicators';
 import DiscussionForm from './DiscussionForm';
 import { Select } from '@/shared/ui/select/Select';
-import { useEffect, useRef, useState } from 'react';
-import { sortType } from '@/entities/discussions/discussions/model/query/discussion.query.type';
+import { useEffect, useRef } from 'react';
 import { useInfiniteDiscussionsQuery } from '@/entities/discussions';
+import { sortType } from '@/shared/model/query/paramsQueryKey';
+import { useDiscussionParams } from '../model/Discussion.sort.context';
 
 interface IDiscussionProps {
   problemId: ProblemId;
 }
 
-interface IPageAble {
-  page: string;
-  size: string;
-  sort: sortType;
-}
 export default function Discussions({ problemId }: IDiscussionProps) {
-  const [pageAble, setPageAble] = useState<IPageAble>({ page: '0', size: '8', sort: '인기순' });
-
+  const { params, setParams } = useDiscussionParams();
   const { data, isPending, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteDiscussionsQuery(problemId, pageAble);
+    useInfiniteDiscussionsQuery(problemId);
 
   const discussions = data?.pages.flatMap((page) => page.content);
   const loaderRef = useRef<HTMLDivElement | null>(null);
@@ -69,10 +64,10 @@ export default function Discussions({ problemId }: IDiscussionProps) {
             <Select
               option={sortOptions}
               title="정렬"
-              value={pageAble.sort}
+              value={params.sort}
               setValue={(value) => {
                 const typedValue = value as sortType;
-                setPageAble((prev) => ({ ...prev, sort: typedValue }));
+                setParams((prev) => ({ ...prev, sort: typedValue, sortBy: typedValue }));
               }}
             />
             {discussions.length < 1 ? (

--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -29,7 +29,7 @@ export default function Discussions({ problemId }: IDiscussionProps) {
   const sortOptions = [
     { label: '인기순', value: '인기순' },
     { label: '최신순', value: '최신순' },
-    { label: '추천 많은 순', value: '추천 많은 순' },
+    { label: '추천순', value: '추천순' },
   ];
 
   useEffect(() => {

--- a/src/features/discussions/disussions/ui/TabsToggle.tsx
+++ b/src/features/discussions/disussions/ui/TabsToggle.tsx
@@ -3,24 +3,22 @@ import { PATHS } from '@/constants/paths';
 import { ProblemId } from '@/shared';
 import clsx from 'clsx';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
 
 export default function TabsToggle({ problemId }: { problemId: ProblemId }) {
-  const [activeTab, setActiveTab] = useState<'problem' | 'discussion'>('problem');
-
   const router = useRouter();
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams.toString());
   params.set('discussion', 'true');
 
+  const active: 'discussion' | 'problem' = searchParams.get('discussion')
+    ? 'discussion'
+    : 'problem';
+
   const handleTabChange = (tab: 'problem' | 'discussion') => {
-    setActiveTab(tab);
     if (tab === 'problem') {
       router.push(`${PATHS.PROBLEMS}/${problemId}`);
-      setActiveTab('problem');
     } else {
       router.push(`?${params.toString()}`);
-      setActiveTab('discussion');
     }
   };
 
@@ -29,8 +27,8 @@ export default function TabsToggle({ problemId }: { problemId: ProblemId }) {
       <button
         onClick={() => handleTabChange('problem')}
         className={clsx(
-          'flex-1 py-3 px-6 rounded-[10px] font-medium transition-all duration-200 text-white',
-          activeTab === 'problem'
+          'flex-1 py-3 px-6 rounded-[10px] font-medium transition-all duration-200',
+          active === 'problem'
             ? 'bg-primary'
             : 'hover:bg-[rgba(255,255,255,0.08)] hover:text-secondary'
         )}
@@ -40,9 +38,9 @@ export default function TabsToggle({ problemId }: { problemId: ProblemId }) {
       <button
         onClick={() => handleTabChange('discussion')}
         className={`flex-1 py-3 px-6 rounded-[10px] font-medium transition-all duration-200 ${
-          activeTab === 'discussion'
-            ? 'bg-[#214d35] text-white shadow-lg'
-            : 'text-white hover:bg-[rgba(255,255,255,0.08)] hover:text-[#00d084]'
+          active === 'discussion'
+            ? 'bg-[#214d35] shadow-lg'
+            : 'text-white hover:bg-[rgba(255,255,255,0.08)] hover:text-secondary'
         }`}
       >
         토론

--- a/src/features/submitCode/submission/ui/CodeEditor.tsx
+++ b/src/features/submitCode/submission/ui/CodeEditor.tsx
@@ -46,7 +46,7 @@ export default function CodeEditor({ onChangeSourceCodeData }: ICodeEditorProps)
         aria-autocomplete="none"
         autoCapitalize="off"
         height="100%"
-        className="h-[450px] overflow-scroll "
+        className="h-[450px] overflow-y-scroll"
       />
     </section>
   );

--- a/src/shared/model/query/paramsQueryKey.ts
+++ b/src/shared/model/query/paramsQueryKey.ts
@@ -1,0 +1,26 @@
+export type sortType = '최신순' | '인기순' | '추천순';
+
+/** select의 value : '실제 리스폰스로 가야하는 값' */
+export const formattedSort: Record<sortType, string> = {
+  인기순: 'best',
+  최신순: 'latest',
+  추천순: 'upvote',
+};
+
+export const INITIAL_PARAMS: IParams = {
+  page: '0',
+  size: '8',
+  sort: '인기순',
+  sortBy: '인기순',
+};
+
+export interface IParams {
+  page?: string;
+  size?: string;
+  sort: sortType;
+  sortBy: sortType;
+}
+
+export const paramsQueryKeys = {
+  key: (key: string, id: string, params: IParams) => [key, id, { ...params }] as const,
+};

--- a/src/shared/ui/userProfile/UserImage.tsx
+++ b/src/shared/ui/userProfile/UserImage.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import Image from 'next/image';
 
 interface IUserImageProps {
   profileImageUrl: string | null;
@@ -8,10 +9,15 @@ interface IUserImageProps {
 export default function UserImage({ profileImageUrl, className = 'size-8' }: IUserImageProps) {
   return (
     <div className={clsx('relative', className)}>
-      <img
+      <Image
         src={profileImageUrl || '/icons/user.svg'}
-        alt="유저 이미지"
-        className="rounded-full object-cover z-10 "
+        alt="유저이미지"
+        fill
+        unoptimized
+        onError={(e) => {
+          e.currentTarget.src = '/icons/user.svg';
+        }}
+        style={{ objectFit: 'contain' }}
       />
       <div className="absolute inset-0 rounded-full bg-gray-500 opacity-30 z-0" />
     </div>

--- a/src/widgets/NavigationBar/ui/index.tsx
+++ b/src/widgets/NavigationBar/ui/index.tsx
@@ -6,7 +6,7 @@ import AuthActions from './AuthActions';
 
 export default async function NavigationBar() {
   return (
-    <header className="border-b border-gray-800 bg-background/95 backdrop-blur-sm sticky top-0 z-50">
+    <header className="border-b border-gray-800 bg-background/95 backdrop-blur-sm sticky top-0 z-50 h-18">
       <nav className="flex w-full justify-around items-center h-full p-4">
         <div className="flex items-center space-x-8">
           <LinkedButton props={NAVIGATE_ATTRIBUTE.root} />


### PR DESCRIPTION
## 🔎 작업 사항

- 토론 글 관련 기능 오류 부분 해결 PR 입니다.
- 해결한 오류 내용 
- discussion CRUD시 바로 반영 안되는 문제
- 토론글에서 프로필 이미지 못불러올시 Image 태그의 onError 처리 (추후 도메인 파악후 추가예정)
- overflow-x-scroll 문제 
- 페이지 전체의 스크롤 삭제

<br>

## ❗️ 전달 사항

- 입력폼 관련 수정 요청은  input merge 이후 수정 예정

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 개선
  - 토론 목록 정렬·페이지 파라미터가 전역으로 관리되어 새로고침·탭 전환 시 상태가 유지됩니다.
  - 토론 생성/수정/삭제 후 목록이 자동으로 최신 상태로 갱신됩니다.

- UI/스타일
  - 문제/토론 영역과 코드 편집기의 스크롤을 세로 전용으로 조정해 스크롤 경험을 개선했습니다.
  - 문제 상세 영역의 상하 여백을 축소해 가시 영역을 확대했습니다.
  - 콘텐츠 높이를 화면 높이에 맞게 계산해 상단 바 높이를 반영했습니다.
  - 내비게이션 바 높이를 명시적으로 설정했습니다.
  - 사용자 프로필 이미지 렌더링을 개선하고, 로드 실패 시 기본 아이콘으로 대체합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->