### PR TITLE
fix : problemId 페이지에서는 globalGlobalFloatingWidget return null 처리

### DIFF
--- a/src/widgets/globalFloatingWidget/ui/index.tsx
+++ b/src/widgets/globalFloatingWidget/ui/index.tsx
@@ -3,13 +3,19 @@ import { useSession } from 'next-auth/react';
 import ChatDialogOpenButton from './ChatDialogOpenButton';
 import GameModalButton from '@/features/game/ui/GameButton';
 import { useCheckCharacterQuery } from '@/entities/game/model/query/game.query';
+import { usePathname } from 'next/navigation';
 
 export function GlobalFloatingWidget() {
+  const problemId = usePathname().split('/')[2];
+
   const { data: session } = useSession();
   const isLogged = session?.accessToken;
 
   const { data: characterData } = useCheckCharacterQuery(!!isLogged);
 
+  if (problemId) {
+    return null;
+  }
   return (
     <div className="fixed top-[calc(100vh-15%)] left-[calc(100vw-5%)] flex flex-col gap-2">
       {isLogged && <ChatDialogOpenButton />}


### PR DESCRIPTION
## 🔎 작업 사항
- problemId 페이지에서는 globalGlobalFloatingWidget return null 처리

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * URL 경로에 세 번째 세그먼트가 있는 페이지(예: 문제 상세 페이지)에서는 글로벌 플로팅 위젯이 표시되지 않도록 했습니다.
  * 해당 조건이 아닌 페이지에서는 기존과 동일하게, 로그인 시 채팅 열기 버튼과 게임 모달 버튼이 노출됩니다.
  * 이로써 상세 페이지에서는 화면 가림 없이 콘텐츠를 이용할 수 있고, 일반 페이지에서는 기존 위젯 경험이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->