### PR TITLE
fix : githubUrl 파라미터를 useGetGitHubRepo 및 useAutoGitPushStatus에 추가하여 유무에 따라 enabled 처리

### DIFF
--- a/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
+++ b/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
@@ -5,29 +5,30 @@ import { IGitPushAutoToggleResponse, TGetReposResponse } from './gitpush.query.t
 import { useSession } from 'next-auth/react';
 
 /**git push */
-export const useGetGitHubRepo = () => {
+export const useGetGitHubRepo = (githubUrl: string | null) => {
   const { data: session } = useSession();
   const accessToken = session?.accessToken?.split(' ')[1] as string;
   return useQuery({
     queryKey: ['get-git-repos'],
     queryFn: async () => {
       const response = await ApiHelper.get<TGetReposResponse>(`${API_URL.GIT}`);
-      return response.data.result || null;
+      return response.data.result;
     },
-    enabled: !!accessToken,
+    enabled: !!accessToken && !!githubUrl,
   });
 };
 
 /**유저의 gitPush auto 유무를 파악합니다. */
-export const useAutoGitPushStatus = () => {
+export const useAutoGitPushStatus = (githubUrl: string | null) => {
   const { data: session } = useSession();
   const accessToken = session?.accessToken?.split(' ')[1] as string;
+
   return useQuery({
     queryKey: ['auto-git-push-status'],
     queryFn: async () => {
       const response = await ApiHelper.get<IGitPushAutoToggleResponse>(`${API_URL.GIT}/status`);
       return response.data.result;
     },
-    enabled: !!accessToken,
+    enabled: !!accessToken && !!githubUrl,
   });
 };

--- a/src/features/submitCode/gitPush/hooks/useGitPush.ts
+++ b/src/features/submitCode/gitPush/hooks/useGitPush.ts
@@ -14,15 +14,15 @@ const gitPushStatusToKor: Record<string, string> = {
   FAILED: 'push에 실패 했습니다',
 };
 
-export default function useGitPush() {
+export default function useGitPush(githubUrl: string | null) {
   const [currentRepo, setCurrentRepo] = useState('');
   const [reposOptions, setReposOptions] = useState<OptionType[]>([]);
   const [isGitPushPending, setIsGitPushPending] = useState(false);
 
   const { mutateAsync: pushAutoToggle } = useGitPushAutoToggleMutation();
   const { mutateAsync: choiceRepo } = useGitRepoChoice();
-  const { data: userRepos } = useGetGitHubRepo();
-  const { data: currentGitPushData } = useAutoGitPushStatus();
+  const { data: userRepos } = useGetGitHubRepo(githubUrl);
+  const { data: currentGitPushData } = useAutoGitPushStatus(githubUrl);
   const { gitPushStatus } = useGitPushStatusStore();
 
   useEffect(() => {

--- a/src/features/submitCode/gitPush/ui/GitPushDialog.tsx
+++ b/src/features/submitCode/gitPush/ui/GitPushDialog.tsx
@@ -30,7 +30,7 @@ export default function GitPushDialog({ githubUrl }: GitPushDialogProps) {
     setCurrentRepo,
     currentGitPushData,
     webSocketGitPushStatus,
-  } = useGitPush();
+  } = useGitPush(githubUrl);
 
   useEffect(() => {
     setGitPushStatus(webSocketGitPushStatus);


### PR DESCRIPTION
## 🔎 작업 사항

github를 등록하지 않은 유저의 경우, github 관련 쿼리에서 undefined가 반환되는 에러 해결
<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Git Push 대화상자에서 GitHub URL을 명시적으로 지정해 저장소 인식 및 상태 추적이 가능해졌습니다.

- 버그 수정
  - URL이 없거나 토큰이 유효하지 않은 경우 자동 상태 조회가 실행되지 않아 불필요한 요청과 오류를 방지합니다.
  - 저장소 정보 조회 시 빈 값 반환을 줄여 더 정확한 결과를 제공합니다.

- 리팩터
  - 데이터 흐름을 URL 중심으로 정비하여 Git Push 관련 화면과 상태 동기화의 일관성과 신뢰성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->