### PR TITLE
select 컴포넌트 수정

### DIFF
--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -72,7 +72,7 @@ export const Select = ({
     lg: 'h-15 text-base w-100 px-4',
   };
   const sizeClass = sizeMap[size];
-
+  const selectedOption = option.find((opt) => typeof opt.value === 'string' && opt.value === value);
   const handleSelectChange = (value: string | (() => void)) => {
     // type 분기
     if (type === 'setValue') {
@@ -116,7 +116,7 @@ export const Select = ({
         )}
         aria-expanded={dropdown}
       >
-        <span className="truncate">{value || '전체'}</span>
+        <span>{selectedOption?.label || '전체'}</span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className={twMerge(


### PR DESCRIPTION


## 🔎 작업 사항

- select 값 선택 시 라벨이 바뀐값으로 들어가는게 아니라 바뀐 value값이 보이는 이슈 수정



## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Select 컴포넌트에 entireOption 옵션 추가(기본값: false). 활성화 시 드롭다운에 “전체” 항목이 표시되며 선택하면 값을 비우고 닫힙니다.
- 개선
  - 선택 버튼 표시가 값 자체가 아닌 해당 옵션의 라벨로 노출됩니다.
  - 현재 값이 문자열이 아니거나 일치하는 옵션을 찾지 못한 경우 “전체”로 표시됩니다.
  - 드롭다운 내 동작(선택/닫기 등)은 기존과 동일하며, 표시 로직만 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->