### PR TITLE
select 수정

### DIFF
--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -72,7 +72,11 @@ export const Select = ({
     lg: 'h-15 text-base w-100 px-4',
   };
   const sizeClass = sizeMap[size];
-  const selectedOption = option.find((opt) => typeof opt.value === 'string' && opt.value === value);
+  const selectedOption =
+    typeof value === 'string'
+      ? option.find((opt) => typeof opt.value === 'string' && opt.value === value)
+      : null;
+
   const handleSelectChange = (value: string | (() => void)) => {
     // type 분기
     if (type === 'setValue') {
@@ -116,7 +120,9 @@ export const Select = ({
         )}
         aria-expanded={dropdown}
       >
-        <span>{selectedOption?.label || '전체'}</span>
+        <span className="truncate">
+          {typeof value === 'string' ? selectedOption?.label || '전체' : value}
+        </span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className={twMerge(


### PR DESCRIPTION

## 🔎 작업 사항

- value에 ReactNode도 받게 수정


## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 문자열 value 사용 시 옵션 목록에서 일치하는 항목의 라벨을 트리거에 표시하도록 수정.
  * 일치 항목이 없으면 기본 텍스트 ‘전체’를 표시하고, ReactNode 형태의 value는 기존대로 렌더링 유지.
  * 외부 API/공개 인터페이스 변경 없음; 표시 텍스트 관련 렌더링 로직만 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->