### PR TITLE
fix : chat 관련 웹소켓 로직 수정 

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
@@ -11,7 +11,6 @@ export default function ChatDialog({ searchParams }: ChatDialogProps) {
   const roomId = use(searchParams)['room-id'];
   const title = use(searchParams)['title'];
 
-  console.log(roomId, title);
   return (
     <Dialog open={!!roomId}>
       <DialogContent

--- a/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
@@ -1,14 +1,17 @@
+'use client';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { ChatRoom, ChatRoomList } from '@/features/chat';
 import { DialogTitle } from '@radix-ui/react-dialog';
+import { use } from 'react';
 
 interface ChatDialogProps {
   searchParams: Promise<{ 'room-id': string; title: string }>;
 }
-export default async function ChatDialog({ searchParams }: ChatDialogProps) {
-  const roomId = (await searchParams)['room-id'];
-  const title = (await searchParams)['title'];
+export default function ChatDialog({ searchParams }: ChatDialogProps) {
+  const roomId = use(searchParams)['room-id'];
+  const title = use(searchParams)['title'];
 
+  console.log(roomId, title);
   return (
     <Dialog open={!!roomId}>
       <DialogContent
@@ -16,8 +19,8 @@ export default async function ChatDialog({ searchParams }: ChatDialogProps) {
         showCloseButton={false}
       >
         <DialogTitle className="hidden" />
-        <ChatRoomList selectedRoomId={roomId} />
-        <ChatRoom roomId={roomId} roomTitle={title} />
+        <ChatRoomList selectedRoomId={Number(roomId)} />
+        <ChatRoom roomId={Number(roomId)} roomTitle={title} />
       </DialogContent>
     </Dialog>
   );

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -4,55 +4,43 @@ import { useEffect } from 'react';
 import { ChatRoomId } from '../../types';
 import { useConnectWebSocket } from '../..';
 import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
-import useLeaveChatRoom from './useLeaveChatRoom';
 
 export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   const { chatStompRef } = useConnectWebSocket();
-  const { setRealTimeMessage, setInitMessages, setIsLeaved } = useChatWebSocketActions();
+  const { setRealTimeMessage, setInitMessages } = useChatWebSocketActions();
   const { isConnected } = useChatWebSocketStore();
-  useLeaveChatRoom(chatStompRef, chatroomId);
 
   useEffect(() => {
     if (!chatroomId) return;
 
     if (!chatStompRef?.current) return;
-    const joinChatRoomReceiptId = 'sub-chatRoom';
-    const chatMessageReceiptId = `sub-message-${chatroomId}-${Date.now()}	`;
 
     if (chatStompRef.current.connected) {
       // 채팅방 메시지 초기 구독
-      chatStompRef.current.subscribe(
-        '/user/queue/chat',
-        (msg: IMessage) => {
-          try {
-            const chats = JSON.parse(msg.body);
+      chatStompRef.current.subscribe('/user/queue/chat', (msg: IMessage) => {
+        try {
+          const chats = JSON.parse(msg.body);
 
-            setInitMessages(chats);
-          } catch (e) {
-            console.error('채팅 내역 파싱 오류', e);
-          }
-        },
-        { receipt: joinChatRoomReceiptId }
-      );
+          setInitMessages(chats);
+        } catch (e) {
+          console.error('채팅 내역 파싱 오류', e);
+        }
+      });
 
       //실시간 메시지 수신 구독
-      chatStompRef.current.subscribe(
-        `/topic/chat/${chatroomId}`,
-        (msg: IMessage) => {
-          try {
-            const parsedBody = JSON.parse(msg.body);
-            setRealTimeMessage({ ...parsedBody });
-          } catch {
-            setRealTimeMessage({
-              message: msg.body,
-              tier: 'LV1',
-              name: '시스템',
-              time: String(new Date()),
-            });
-          }
-        },
-        { receipt: chatMessageReceiptId }
-      );
+      chatStompRef.current.subscribe(`/topic/chat/${chatroomId}`, (msg: IMessage) => {
+        try {
+          const parsedBody = JSON.parse(msg.body);
+          setRealTimeMessage({ ...parsedBody });
+        } catch {
+          setRealTimeMessage({
+            message: msg.body,
+            tier: 'LV1',
+            name: '시스템',
+            time: String(new Date()),
+          });
+        }
+      });
 
       // 입장 메시지 전송
       chatStompRef.current.publish({
@@ -62,7 +50,7 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
     }
 
     return () => {
-      setIsLeaved(true);
+      // setIsLeaved(true);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected, chatStompRef, chatroomId]);

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -1,8 +1,7 @@
 'use client';
 import { IMessage } from '@stomp/stompjs';
-import { useEffect } from 'react';
-import { ChatRoomId } from '../../types';
-import { useConnectWebSocket } from '../..';
+import { useRef, useEffect } from 'react';
+import { ChatRoomId, useConnectWebSocket } from '../..';
 import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
 
 export default function useJoinChatRoom(chatroomId: ChatRoomId) {
@@ -10,37 +9,44 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   const { setRealTimeMessage, setInitMessages } = useChatWebSocketActions();
   const { isConnected } = useChatWebSocketStore();
 
-  useEffect(() => {
-    if (!chatroomId) return;
+  // 구독 객체 저장용 ref
+  const userQueueSubRef = useRef<any>(null);
+  const topicSubRef = useRef<any>(null);
 
-    if (!chatStompRef?.current) return;
+  useEffect(() => {
+    if (!chatroomId || !chatStompRef?.current) return;
 
     if (chatStompRef.current.connected) {
-      // 채팅방 메시지 초기 구독
-      chatStompRef.current.subscribe('/user/queue/chat', (msg: IMessage) => {
-        try {
-          const chats = JSON.parse(msg.body);
-
-          setInitMessages(chats);
-        } catch (e) {
-          console.error('채팅 내역 파싱 오류', e);
+      // 채팅방 메시지 초기 구독후 구독 객체 저장
+      userQueueSubRef.current = chatStompRef.current.subscribe(
+        '/user/queue/chat',
+        (msg: IMessage) => {
+          try {
+            const chats = JSON.parse(msg.body);
+            setInitMessages(chats);
+          } catch (e) {
+            console.error('채팅 내역 파싱 오류', e);
+          }
         }
-      });
+      );
 
-      //실시간 메시지 수신 구독
-      chatStompRef.current.subscribe(`/topic/chat/${chatroomId}`, (msg: IMessage) => {
-        try {
-          const parsedBody = JSON.parse(msg.body);
-          setRealTimeMessage({ ...parsedBody });
-        } catch {
-          setRealTimeMessage({
-            message: msg.body,
-            tier: 'LV1',
-            name: '시스템',
-            time: String(new Date()),
-          });
+      //실시간 메시지 수신 구독후 구독 객체 저장
+      topicSubRef.current = chatStompRef.current.subscribe(
+        `/topic/chat/${chatroomId}`,
+        (msg: IMessage) => {
+          try {
+            const parsedBody = JSON.parse(msg.body);
+            setRealTimeMessage({ ...parsedBody });
+          } catch {
+            setRealTimeMessage({
+              message: msg.body,
+              tier: 'LV1',
+              name: '시스템',
+              time: String(new Date()),
+            });
+          }
         }
-      });
+      );
 
       // 입장 메시지 전송
       chatStompRef.current.publish({
@@ -50,7 +56,15 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
     }
 
     return () => {
-      // setIsLeaved(true);
+      // cleanup에서 구독 해지
+      if (userQueueSubRef.current) {
+        userQueueSubRef.current.unsubscribe();
+        userQueueSubRef.current = null;
+      }
+      if (topicSubRef.current) {
+        topicSubRef.current.unsubscribe();
+        topicSubRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected, chatStompRef, chatroomId]);

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -7,14 +7,13 @@ import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useC
 
 export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   const { chatStompRef } = useConnectWebSocket();
-  const { setMessage, setInitMessages } = useChatWebSocketActions();
+  const { setRealTimeMessage, setInitMessages } = useChatWebSocketActions();
   const { isConnected } = useChatWebSocketStore();
 
   useEffect(() => {
     if (chatroomId === 0) return;
 
     if (!chatStompRef?.current) return;
-    if (!isConnected) return;
     const joinChatRoomReceiptId = 'sub-chatRoom';
     const chatMessageReceiptId = `sub-message-${chatroomId}-${Date.now()}	`;
 
@@ -40,9 +39,9 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
         (msg: IMessage) => {
           try {
             const parsedBody = JSON.parse(msg.body);
-            setMessage({ ...parsedBody });
+            setRealTimeMessage({ ...parsedBody });
           } catch {
-            setMessage({
+            setRealTimeMessage({
               message: msg.body,
               tier: 'LV1',
               name: '시스템',

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -4,11 +4,13 @@ import { useEffect } from 'react';
 import { ChatRoomId } from '../../types';
 import { useConnectWebSocket } from '../..';
 import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
+import useLeaveChatRoom from './useLeaveChatRoom';
 
 export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   const { chatStompRef } = useConnectWebSocket();
-  const { setRealTimeMessage, setInitMessages } = useChatWebSocketActions();
+  const { setRealTimeMessage, setInitMessages, setIsLeaved } = useChatWebSocketActions();
   const { isConnected } = useChatWebSocketStore();
+  useLeaveChatRoom(chatStompRef, chatroomId);
 
   useEffect(() => {
     if (chatroomId === 0) return;
@@ -58,6 +60,10 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
         body: String(chatroomId),
       });
     }
+
+    return () => {
+      setIsLeaved(true);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected, chatStompRef, chatroomId]);
 }

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -1,5 +1,5 @@
 'use client';
-import { IMessage } from '@stomp/stompjs';
+import { IMessage, StompSubscription } from '@stomp/stompjs';
 import { useRef, useEffect } from 'react';
 import { ChatRoomId, useConnectWebSocket } from '../..';
 import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
@@ -10,8 +10,8 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   const { isConnected } = useChatWebSocketStore();
 
   // 구독 객체 저장용 ref
-  const userQueueSubRef = useRef<any>(null);
-  const topicSubRef = useRef<any>(null);
+  const userQueueSubRef = useRef<StompSubscription | null>(null);
+  const topicSubRef = useRef<StompSubscription | null>(null);
 
   useEffect(() => {
     if (!chatroomId || !chatStompRef?.current) return;

--- a/src/features/chat/hooks/socket/useJoinChatRoom.ts
+++ b/src/features/chat/hooks/socket/useJoinChatRoom.ts
@@ -13,7 +13,7 @@ export default function useJoinChatRoom(chatroomId: ChatRoomId) {
   useLeaveChatRoom(chatStompRef, chatroomId);
 
   useEffect(() => {
-    if (chatroomId === 0) return;
+    if (!chatroomId) return;
 
     if (!chatStompRef?.current) return;
     const joinChatRoomReceiptId = 'sub-chatRoom';

--- a/src/features/chat/hooks/socket/useLeaveChatRoom.ts
+++ b/src/features/chat/hooks/socket/useLeaveChatRoom.ts
@@ -1,0 +1,33 @@
+'use client';
+import { RefObject, useEffect } from 'react';
+import { ChatRoomId } from '../../types';
+import useChatWebSocketStore, { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
+import { Client } from '@stomp/stompjs';
+
+export default function useLeaveChatRoom(
+  chatStompRef: RefObject<Client | null>,
+  chatroomId: ChatRoomId
+) {
+  const { isLeaveRoom } = useChatWebSocketStore();
+  const { clearMessages } = useChatWebSocketActions();
+
+  console.log(isLeaveRoom);
+  useEffect(() => {
+    if (chatroomId === 0 || !chatStompRef?.current || !isLeaveRoom) return;
+    console.log('퇴장 훅 실행');
+    if (chatStompRef.current?.connected) {
+      try {
+        chatStompRef.current.publish({
+          destination: `/chat/rooms/${chatroomId}/leave`,
+          body: String(chatroomId),
+        });
+      } catch (err) {
+        console.error('퇴장 메시지 전송 오류', err);
+      } finally {
+        clearMessages();
+      }
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatStompRef, chatroomId, isLeaveRoom]);
+}

--- a/src/features/chat/hooks/socket/useLeaveChatRoom.ts
+++ b/src/features/chat/hooks/socket/useLeaveChatRoom.ts
@@ -11,7 +11,6 @@ export default function useLeaveChatRoom(
   const { isLeaveRoom } = useChatWebSocketStore();
   const { clearMessages } = useChatWebSocketActions();
 
-  console.log(isLeaveRoom);
   useEffect(() => {
     if (chatroomId === 0 || !chatStompRef?.current || !isLeaveRoom) return;
     console.log('퇴장 훅 실행');

--- a/src/features/chat/hooks/socket/useSubChatRooms.ts
+++ b/src/features/chat/hooks/socket/useSubChatRooms.ts
@@ -12,7 +12,7 @@ export default function useSubChatRooms() {
 
   useEffect(() => {
     if (!chatStompRef.current) return;
-    if (!isConnected) return;
+    if (!chatStompRef.current.connected) return;
 
     const roomReceiptId = 'sub-chatrooms';
     const roomUpdateReceiptId = 'sub-roomUpdate';

--- a/src/features/chat/hooks/useChatDialogTrigger.ts
+++ b/src/features/chat/hooks/useChatDialogTrigger.ts
@@ -9,7 +9,7 @@ export default function useChatDialogTrigger() {
   const { setIsLeaved } = useChatWebSocketActions();
 
   const openChatDialog = () => {
-    params.set(PATHS.CHAT.SEARCHPARAMS_ID, '0');
+    params.set(PATHS.CHAT.SEARCHPARAMS_ID, 'NaN');
     params.set(PATHS.CHAT.SEARCHPARAMS_TITLE, 'null');
 
     router.push(`?${params.toString()}`);

--- a/src/features/chat/hooks/useChatDialogTrigger.ts
+++ b/src/features/chat/hooks/useChatDialogTrigger.ts
@@ -1,10 +1,12 @@
 import { PATHS } from '@/constants/paths';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useChatWebSocketActions } from '../model/useChatWebSocketStore';
 
 export default function useChatDialogTrigger() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const params = new URLSearchParams(searchParams.toString());
+  const { setIsLeaved } = useChatWebSocketActions();
 
   const openChatDialog = () => {
     params.set(PATHS.CHAT.SEARCHPARAMS_ID, '0');
@@ -15,13 +17,18 @@ export default function useChatDialogTrigger() {
 
   const handleSwitchRoom = (roomId: number, title: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set(PATHS.CHAT.SEARCHPARAMS_ID, String(roomId));
-    params.set(PATHS.CHAT.SEARCHPARAMS_TITLE, title);
+    const prevRoomId = params.get(PATHS.CHAT.SEARCHPARAMS_ID);
+    if (prevRoomId && Number(prevRoomId) !== roomId) {
+      setIsLeaved(true);
+      params.set(PATHS.CHAT.SEARCHPARAMS_ID, String(roomId));
+      params.set(PATHS.CHAT.SEARCHPARAMS_TITLE, title);
 
-    router.push(`?${params.toString()}`);
+      router.push(`?${params.toString()}`);
+    }
   };
 
   const closeChatDialog = () => {
+    setIsLeaved(true);
     params.delete(PATHS.CHAT.SEARCHPARAMS_ID);
     params.delete(PATHS.CHAT.SEARCHPARAMS_TITLE);
 

--- a/src/features/chat/hooks/useChatDialogTrigger.ts
+++ b/src/features/chat/hooks/useChatDialogTrigger.ts
@@ -1,12 +1,11 @@
 import { PATHS } from '@/constants/paths';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useChatWebSocketActions } from '../model/useChatWebSocketStore';
 
 export default function useChatDialogTrigger() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const params = new URLSearchParams(searchParams.toString());
-  const { setIsLeaved } = useChatWebSocketActions();
+  // const { setIsLeaved } = useChatWebSocketActions();
 
   const openChatDialog = () => {
     params.set(PATHS.CHAT.SEARCHPARAMS_ID, 'NaN');
@@ -19,7 +18,7 @@ export default function useChatDialogTrigger() {
     const params = new URLSearchParams(searchParams.toString());
     const prevRoomId = params.get(PATHS.CHAT.SEARCHPARAMS_ID);
     if (prevRoomId && Number(prevRoomId) !== roomId) {
-      setIsLeaved(true);
+      // setIsLeaved(true);
       params.set(PATHS.CHAT.SEARCHPARAMS_ID, String(roomId));
       params.set(PATHS.CHAT.SEARCHPARAMS_TITLE, title);
 
@@ -28,7 +27,7 @@ export default function useChatDialogTrigger() {
   };
 
   const closeChatDialog = () => {
-    setIsLeaved(true);
+    // setIsLeaved(true);
     params.delete(PATHS.CHAT.SEARCHPARAMS_ID);
     params.delete(PATHS.CHAT.SEARCHPARAMS_TITLE);
 

--- a/src/features/chat/hooks/useChatMessage.ts
+++ b/src/features/chat/hooks/useChatMessage.ts
@@ -15,8 +15,8 @@ export default function useChatMessage(roomId: number) {
     setValue('');
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       createMessage();
     }
@@ -27,6 +27,6 @@ export default function useChatMessage(roomId: number) {
     setValue,
     handleChangeMessage,
     createMessage,
-    handleKeyPress,
+    handleKeyDown,
   };
 }

--- a/src/features/chat/model/useChatWebSocketStore.ts
+++ b/src/features/chat/model/useChatWebSocketStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { useShallow } from 'zustand/shallow';
-import { IChatMessage, IChatWebSocketStore, INITIAL_STATE } from './useChatWebSocketStore.types';
+import { IChatWebSocketStore, INITIAL_STATE } from './useChatWebSocketStore.types';
 
 /** 인증 스토어 */
 const useChatWebSocketStore = create<IChatWebSocketStore>()(
@@ -11,6 +11,11 @@ const useChatWebSocketStore = create<IChatWebSocketStore>()(
       setIsConnected: (status) => {
         set({
           isConnected: status,
+        });
+      },
+      setIsLeaved: (status) => {
+        set({
+          isLeaveRoom: status,
         });
       },
 
@@ -85,6 +90,8 @@ export function useChatWebSocketActions() {
   return useChatWebSocketStore(
     useShallow((state) => ({
       setIsConnected: state.actions.setIsConnected,
+      setIsLeaved: state.actions.setIsLeaved,
+
       setInitRooms: state.actions.setInitRooms,
       setRooms: state.actions.setRooms,
       setInitMessages: state.actions.setInitMessages,

--- a/src/features/chat/model/useChatWebSocketStore.ts
+++ b/src/features/chat/model/useChatWebSocketStore.ts
@@ -50,24 +50,23 @@ const useChatWebSocketStore = create<IChatWebSocketStore>()(
 
       setInitMessages: (messages) => {
         set({
-          messages: Array.isArray(messages) ? messages : [],
+          initMessages: Array.isArray(messages) ? messages : [],
         });
       },
 
-      setMessage: (message) => {
+      setRealTimeMessage: (message) => {
         set((state) => {
-          const newMessages = [...(state.messages ?? []), message] as Array<IChatMessage>;
-          newMessages.sort((a, b) => Number(a.time) - Number(b.time));
           return {
             ...state,
-            messages: newMessages as IChatMessage[],
+            realTimeMessages: [...state.realTimeMessages, message],
           };
         });
       },
 
       clearMessages: () => {
         set({
-          messages: [],
+          initMessages: [],
+          realTimeMessages: [],
         });
       },
 
@@ -89,7 +88,7 @@ export function useChatWebSocketActions() {
       setInitRooms: state.actions.setInitRooms,
       setRooms: state.actions.setRooms,
       setInitMessages: state.actions.setInitMessages,
-      setMessage: state.actions.setMessage,
+      setRealTimeMessage: state.actions.setRealTimeMessage,
 
       clearMessages: state.actions.clearMessages,
       clearStore: state.actions.clearStore,

--- a/src/features/chat/model/useChatWebSocketStore.types.ts
+++ b/src/features/chat/model/useChatWebSocketStore.types.ts
@@ -16,18 +16,20 @@ export interface IChatMessage {
   time: string;
 }
 
-/** setMessage 상태 인터페이스 */
+/** store state 인터페이스 */
 export interface IInitialState {
   isConnected: boolean;
   rooms: IChatRoom[] | [];
-  messages: IChatMessage[] | [];
+  initMessages: IChatMessage[] | [];
+  realTimeMessages: IChatMessage[] | [];
 }
 
 /**store 초기 상태*/
 export const INITIAL_STATE: IInitialState = {
   isConnected: false,
   rooms: [],
-  messages: [],
+  initMessages: [],
+  realTimeMessages: [],
 };
 
 /** 스토어 액션 인터페이스 */
@@ -37,8 +39,7 @@ interface IChatWebSocketStoreActions {
     setInitRooms: (rooms: IChatRoom[] | []) => void;
     setRooms: (response: IChatRoom) => void;
     setInitMessages: (message: IChatMessage[]) => void;
-    setMessage: (message: IChatMessage) => void;
-    setEnterMessage: (message: string) => void;
+    setRealTimeMessage: (message: IChatMessage) => void;
     clearMessages: () => void;
     clearStore: () => void;
   };

--- a/src/features/chat/model/useChatWebSocketStore.types.ts
+++ b/src/features/chat/model/useChatWebSocketStore.types.ts
@@ -19,6 +19,7 @@ export interface IChatMessage {
 /** store state 인터페이스 */
 export interface IInitialState {
   isConnected: boolean;
+  isLeaveRoom: boolean;
   rooms: IChatRoom[] | [];
   initMessages: IChatMessage[] | [];
   realTimeMessages: IChatMessage[] | [];
@@ -27,6 +28,7 @@ export interface IInitialState {
 /**store 초기 상태*/
 export const INITIAL_STATE: IInitialState = {
   isConnected: false,
+  isLeaveRoom: false,
   rooms: [],
   initMessages: [],
   realTimeMessages: [],
@@ -36,6 +38,7 @@ export const INITIAL_STATE: IInitialState = {
 interface IChatWebSocketStoreActions {
   actions: {
     setIsConnected: (status: boolean) => void;
+    setIsLeaved: (status: boolean) => void;
     setInitRooms: (rooms: IChatRoom[] | []) => void;
     setRooms: (response: IChatRoom) => void;
     setInitMessages: (message: IChatMessage[]) => void;

--- a/src/features/chat/types/index.ts
+++ b/src/features/chat/types/index.ts
@@ -2,4 +2,4 @@ export interface ChatRoomPageProps {
   params: Promise<{ chatRoomId: string }>;
 }
 
-export type ChatRoomId = number | null;
+export type ChatRoomId = number | typeof NaN;

--- a/src/features/chat/ui/chatMessage/ChatMessage.tsx
+++ b/src/features/chat/ui/chatMessage/ChatMessage.tsx
@@ -2,10 +2,9 @@
 import { formatDate } from '@/shared/util/formatDate';
 import { IChatMessageProps } from './SystemMessage';
 
-export default function ChatMessage({ msg }: IChatMessageProps) {
-  const isOwn = true;
+export default function ChatMessage({ msg, userNickname }: IChatMessageProps) {
+  const isOwn = msg.name === userNickname;
   const formattedDate = formatDate(msg.time);
-  console.log(formattedDate);
 
   return (
     <li className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>

--- a/src/features/chat/ui/chatMessage/SystemMessage.tsx
+++ b/src/features/chat/ui/chatMessage/SystemMessage.tsx
@@ -2,6 +2,7 @@ import { IChatMessage } from '../../model/useChatWebSocketStore.types';
 
 export interface IChatMessageProps {
   msg: IChatMessage;
+  userNickname?: string;
 }
 export default function SystemMessage({ msg }: IChatMessageProps) {
   return (

--- a/src/features/chat/ui/chatRoom/ChatInput.tsx
+++ b/src/features/chat/ui/chatRoom/ChatInput.tsx
@@ -6,9 +6,7 @@ import { Send } from 'lucide-react';
 import UnifiedInput from '@/shared/ui/InputFiled';
 
 export default function ChatInput({ chatRoomId }: { chatRoomId: ChatRoomId }) {
-  const { value, handleChangeMessage, createMessage, handleKeyPress } = useChatMessage(
-    Number(chatRoomId)
-  );
+  const { value, handleChangeMessage, createMessage, handleKeyDown } = useChatMessage(chatRoomId);
   return (
     <div className="p-4 border-t border-primary/20">
       <div className="flex items-end space-x-3">
@@ -17,10 +15,12 @@ export default function ChatInput({ chatRoomId }: { chatRoomId: ChatRoomId }) {
           name="chat"
           value={value}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleChangeMessage(e)}
-          onKeyDown={handleKeyPress}
+          onKeyDown={handleKeyDown}
           className="border-primary rounded-[10px] min-h-5 focus:outline-none focus:border-secondary/70"
         />
         <button
+          aria-label="send message"
+          type="button"
           onClick={createMessage}
           disabled={!value.trim()}
           className="bg-[#214d35] hover:bg-[#276e48] disabled:bg-[#214d35]/50 disabled:cursor-not-allowed text-white p-3 rounded-[10px] transition-all duration-200 hover:shadow-lg active:scale-95"

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -16,23 +16,32 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   useJoinChatRoom(roomId);
   const { data } = useMyInfoQuery();
   const nickname = data?.data.result.nickname;
-  const { messages } = useChatWebSocketStore();
+  const { initMessages, realTimeMessages } = useChatWebSocketStore();
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">
       {roomId !== 0 ? (
         <>
           <ChatRoomHeader roomTitle={roomTitle} />
-          {messages && (
-            <ul className="flex-1 p-4 flex flex-col gap-4">
-              {messages.map((msg, i) => {
-                if (msg.name === '시스템') {
-                  return <SystemMessage msg={msg} key={i} />;
-                }
-                return <ChatMessage msg={msg} key={i} userNickname={nickname} />;
-              })}
-            </ul>
-          )}
+          <div className="flex-1 p-4 flex flex-col gap-4 overflow-y-scroll">
+            {initMessages && (
+              <ul className="flex flex-col gap-4 h-fit">
+                {initMessages.map((msg, i) => (
+                  <ChatMessage msg={msg} key={i} userNickname={nickname} />
+                ))}
+              </ul>
+            )}
+            {realTimeMessages && (
+              <ul className="flex flex-col gap-4 h-fit">
+                {realTimeMessages.map((msg, i) => {
+                  if (msg.name === '시스템') {
+                    return <SystemMessage msg={msg} key={i} />;
+                  }
+                  return <ChatMessage msg={msg} key={i} userNickname={nickname} />;
+                })}
+              </ul>
+            )}
+          </div>
           <ChatInput chatRoomId={roomId} />
         </>
       ) : (

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -5,18 +5,22 @@ import useChatWebSocketStore from '@/features/chat/model/useChatWebSocketStore';
 import SystemMessage from '../chatMessage/SystemMessage';
 import ChatMessage from '../chatMessage/ChatMessage';
 import ChatRoomHeader from './ChatRoomHeader';
+import { useMyInfoQuery } from '@/entities/mypage/model/query';
 
 interface ChatProps {
-  roomId: string;
+  roomId: number;
   roomTitle: string;
 }
 
 export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
-  useJoinChatRoom(Number(roomId));
+  useJoinChatRoom(roomId);
+  const { data } = useMyInfoQuery();
+  const nickname = data?.data.result.nickname;
   const { messages } = useChatWebSocketStore();
+
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">
-      {roomId !== '0' ? (
+      {roomId !== 0 ? (
         <>
           <ChatRoomHeader roomTitle={roomTitle} />
           {messages && (
@@ -25,11 +29,11 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
                 if (msg.name === '시스템') {
                   return <SystemMessage msg={msg} key={i} />;
                 }
-                return <ChatMessage msg={msg} key={i} />;
+                return <ChatMessage msg={msg} key={i} userNickname={nickname} />;
               })}
             </ul>
           )}
-          <ChatInput chatRoomId={Number(roomId)} />
+          <ChatInput chatRoomId={roomId} />
         </>
       ) : (
         <div className="flex flex-col justify-center  items-center">

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import { ChatInput, useJoinChatRoom } from '@/features/chat';
-import useChatWebSocketStore, {
-  useChatWebSocketActions,
-} from '@/features/chat/model/useChatWebSocketStore';
+import useChatWebSocketStore from '@/features/chat/model/useChatWebSocketStore';
 import SystemMessage from '../chatMessage/SystemMessage';
 import ChatMessage from '../chatMessage/ChatMessage';
 import ChatRoomHeader from './ChatRoomHeader';
 import { useMyInfoQuery } from '@/entities/mypage/model/query';
-import { useEffect } from 'react';
 
 interface ChatProps {
   roomId: number;
@@ -20,11 +17,11 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   const { data } = useMyInfoQuery();
   const nickname = data?.data.result.nickname;
   const { initMessages, realTimeMessages } = useChatWebSocketStore();
-  const { setIsLeaved } = useChatWebSocketActions();
+  // const { setIsLeaved } = useChatWebSocketActions();
 
-  useEffect(() => {
-    setIsLeaved(false);
-  }, [roomId]);
+  // useEffect(() => {
+  //   setIsLeaved(false);
+  // }, [roomId]);
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { ChatInput, useJoinChatRoom } from '@/features/chat';
-import useChatWebSocketStore from '@/features/chat/model/useChatWebSocketStore';
+import useChatWebSocketStore, {
+  useChatWebSocketActions,
+} from '@/features/chat/model/useChatWebSocketStore';
 import SystemMessage from '../chatMessage/SystemMessage';
 import ChatMessage from '../chatMessage/ChatMessage';
 import ChatRoomHeader from './ChatRoomHeader';
 import { useMyInfoQuery } from '@/entities/mypage/model/query';
+import { useEffect } from 'react';
 
 interface ChatProps {
   roomId: number;
@@ -17,6 +20,11 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   const { data } = useMyInfoQuery();
   const nickname = data?.data.result.nickname;
   const { initMessages, realTimeMessages } = useChatWebSocketStore();
+  const { setIsLeaved } = useChatWebSocketActions();
+
+  useEffect(() => {
+    setIsLeaved(false);
+  }, [roomId]);
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -28,7 +28,7 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">
-      {roomId !== 0 ? (
+      {!!roomId ? (
         <>
           <ChatRoomHeader roomTitle={roomTitle} />
           <div className="flex-1 p-4 flex flex-col gap-4 overflow-y-scroll">

--- a/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
+++ b/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
@@ -2,7 +2,6 @@
 import { IChatRoom } from '../../model/useChatWebSocketStore.types';
 import clsx from 'clsx';
 import useChatDialogTrigger from '../../hooks/useChatDialogTrigger';
-import { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
 
 interface IChatRoomItemProps {
   room: IChatRoom;
@@ -12,12 +11,6 @@ interface IChatRoomItemProps {
 export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
   const { roomId, title, headCount } = room;
   const { handleSwitchRoom } = useChatDialogTrigger();
-  const { clearMessages } = useChatWebSocketActions();
-
-  const handleClick = () => {
-    clearMessages();
-    handleSwitchRoom(roomId, title);
-  };
 
   return (
     <li
@@ -25,7 +18,7 @@ export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
         'p-3 rounded-[10px] cursor-pointer transition-all duration-200 w-full  text-white',
         isSelected ? 'bg-primary' : 'hover:text-secondary hover:bg-white/8 '
       )}
-      onClick={handleClick}
+      onClick={() => handleSwitchRoom(roomId, title)}
     >
       <p className="font-medium truncate">{title}</p>
       <p className="text-sm text-[#ccc] truncate"> {headCount}명</p>

--- a/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
+++ b/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
@@ -2,6 +2,7 @@
 import { IChatRoom } from '../../model/useChatWebSocketStore.types';
 import clsx from 'clsx';
 import useChatDialogTrigger from '../../hooks/useChatDialogTrigger';
+import { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
 
 interface IChatRoomItemProps {
   room: IChatRoom;
@@ -11,6 +12,12 @@ interface IChatRoomItemProps {
 export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
   const { roomId, title, headCount } = room;
   const { handleSwitchRoom } = useChatDialogTrigger();
+  const { clearMessages } = useChatWebSocketActions();
+
+  const handleClick = () => {
+    handleSwitchRoom(roomId, title);
+    clearMessages();
+  };
 
   return (
     <li
@@ -18,7 +25,7 @@ export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
         'p-3 rounded-[10px] cursor-pointer transition-all duration-200 w-full  text-white',
         isSelected ? 'bg-primary' : 'hover:text-secondary hover:bg-white/8 '
       )}
-      onClick={() => handleSwitchRoom(roomId, title)}
+      onClick={handleClick}
     >
       <p className="font-medium truncate">{title}</p>
       <p className="text-sm text-[#ccc] truncate"> {headCount}명</p>

--- a/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
+++ b/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
@@ -15,8 +15,8 @@ export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
   const { clearMessages } = useChatWebSocketActions();
 
   const handleClick = () => {
-    handleSwitchRoom(roomId, title);
     clearMessages();
+    handleSwitchRoom(roomId, title);
   };
 
   return (

--- a/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
+++ b/src/features/chat/ui/chatRoomList/ChatRoomItem.tsx
@@ -2,6 +2,7 @@
 import { IChatRoom } from '../../model/useChatWebSocketStore.types';
 import clsx from 'clsx';
 import useChatDialogTrigger from '../../hooks/useChatDialogTrigger';
+import { useChatWebSocketActions } from '../../model/useChatWebSocketStore';
 
 interface IChatRoomItemProps {
   room: IChatRoom;
@@ -11,6 +12,7 @@ interface IChatRoomItemProps {
 export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
   const { roomId, title, headCount } = room;
   const { handleSwitchRoom } = useChatDialogTrigger();
+  const { clearMessages } = useChatWebSocketActions();
 
   return (
     <li
@@ -18,7 +20,10 @@ export default function ChatRoomItem({ room, isSelected }: IChatRoomItemProps) {
         'p-3 rounded-[10px] cursor-pointer transition-all duration-200 w-full  text-white',
         isSelected ? 'bg-primary' : 'hover:text-secondary hover:bg-white/8 '
       )}
-      onClick={() => handleSwitchRoom(roomId, title)}
+      onClick={() => {
+        handleSwitchRoom(roomId, title);
+        clearMessages();
+      }}
     >
       <p className="font-medium truncate">{title}</p>
       <p className="text-sm text-[#ccc] truncate"> {headCount}명</p>

--- a/src/features/chat/ui/chatRoomList/index.tsx
+++ b/src/features/chat/ui/chatRoomList/index.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image';
 import useChatDialogTrigger from '../../hooks/useChatDialogTrigger';
 
 interface IChatRoomListProps {
-  selectedRoomId: string;
+  selectedRoomId: number;
 }
 export default function ChatRoomList({ selectedRoomId }: IChatRoomListProps) {
   useSubChatRooms();
@@ -48,7 +48,7 @@ export default function ChatRoomList({ selectedRoomId }: IChatRoomListProps) {
                 <ChatRoomItem
                   key={room.roomId}
                   room={room}
-                  isSelected={Number(selectedRoomId) === room.roomId}
+                  isSelected={selectedRoomId === room.roomId}
                 />
               );
             })}

--- a/src/features/submitCode/submission/hooks/useSubmitForReview.ts
+++ b/src/features/submitCode/submission/hooks/useSubmitForReview.ts
@@ -30,6 +30,7 @@ export default function useSubmitForReview(problemId: ProblemId) {
     if (codeReviewData) {
       setCodeReview(codeReviewData);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reviewTokenData, codeReviewData]);
 
   return {

--- a/src/features/submitCode/submission/hooks/useSubscribeProblem.ts
+++ b/src/features/submitCode/submission/hooks/useSubscribeProblem.ts
@@ -45,10 +45,12 @@ export default function useSubscribeProblem() {
         clearStore();
       };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isConnected,
     setResults,
     clearStore,
+    problemStompRef,
     submitPrepareData.sessionKey,
     problemStompRef.current?.connected,
   ]);

--- a/src/lib/AuthGuard.tsx
+++ b/src/lib/AuthGuard.tsx
@@ -28,7 +28,7 @@ export default function AuthGuard() {
     } else {
       setShowLoginModal(false);
     }
-  }, [status, pathname, session, searchParams]);
+  }, [status, pathname, session, searchParams, hasAuthGuardTrigger]);
 
   const handleCloseLoginModal = () => {
     router.back();

--- a/src/shared/util/formatDate.ts
+++ b/src/shared/util/formatDate.ts
@@ -1,13 +1,12 @@
 export const formatDate = (date: string): string => {
   const newDate = new Date(date);
+  newDate.setHours(newDate.getHours() + 9);
 
-  const options: Intl.DateTimeFormatOptions = {
+  const formatter = new Intl.DateTimeFormat('ko-KR', {
     hour: 'numeric',
     minute: 'numeric',
     hour12: true,
     timeZone: 'Asia/Seoul',
-  };
-
-  const formatter = new Intl.DateTimeFormat('ko-KR', options);
-  return formatter.format(newDate); // 예: "오후 4:58"
+  });
+  return formatter.format(newDate);
 };


### PR DESCRIPTION
## 🔎 작업 사항

- 웹소켓 서버에서 보내주는 시간과 현재 시간 오류 수정
- 웹소켓 구독해제로직 클린업에 추가
- 한글로 입력후 엔터로 메시지 전송시 2개가 가는 문제 해결
- 닉네임으로 내가보낸 메시지, 상대방이 보낸 메시지 구분

<br>

## ❗️ 전달 사항

- 현재 채팅 모달이 홈페이지에서만 열리는 오류가 있습니다. 이후 pr 에서 해결 예정 입니다.

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 채팅 퇴장 처리 훅 추가 및 입장/퇴장 알림 전송으로 채팅 상태 관리 강화.
  - 초기 대화와 실시간 메시지를 분리해 별도 목록으로 표시.

- **버그 수정**
  - IME 조합 중 Enter 전송 방지.
  - 한국 표준시로 시간 표기 일관화.
  - 웹소켓 구독 해제 추가로 중복/유령 메시지 감소 및 클린업 강화.

- **리팩터**
  - 닉네임 기반 내 메시지 판별로 정확도 향상.
  - 채팅 전환 불필요 네비게이션 방지 및 전송 버튼 접근성 속성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->