### PR TITLE
fix : 랜딩페이지에서만 채팅 모달이 팝업되는 문제 해결

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/@chatDialog/page.tsx
@@ -2,15 +2,17 @@
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { ChatRoom, ChatRoomList } from '@/features/chat';
 import { DialogTitle } from '@radix-ui/react-dialog';
-import { use } from 'react';
+import { useSearchParams } from 'next/navigation';
 
-interface ChatDialogProps {
-  searchParams: Promise<{ 'room-id': string; title: string }>;
-}
-export default function ChatDialog({ searchParams }: ChatDialogProps) {
-  const roomId = use(searchParams)['room-id'];
-  const title = use(searchParams)['title'];
+export default function ChatDialog({}) {
+  const sp = useSearchParams();
 
+  const roomId = sp.get('room-id');
+  const title = sp.get('title');
+
+  if (!roomId || !title) {
+    return null;
+  }
   return (
     <Dialog open={!!roomId}>
       <DialogContent


### PR DESCRIPTION
## 🔎 작업 사항

- 랜딩페이지에서만 채팅 모달이 팝업되는 문제 해결

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - URL에 필요한 항목(대화방 ID, 제목)이 없을 때 화면이 잘못 표시되던 사례를 방지하여 안정성을 개선했습니다.
- 리팩터링
  - 페이지가 주소(URL)와 더 일관되게 동작하도록 검색 매개변수 처리 방식을 단순화했습니다.
- 기타
  - 불필요한 컴포넌트 입력값 의존성을 제거해 로딩 및 표시 동작을 더 예측 가능하게 만들었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->