### PR TITLE
fix : 문제 리스트 페이지 api body값 수정

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
@@ -73,7 +73,7 @@ const FilterSelect = ({ children }: { children: ReactNode }) => {
 };
 
 const ProblemsList = () => {
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
 
   const difficultyOptions = [
     { label: 'LV1', value: 'LV1' },

--- a/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
@@ -107,25 +107,27 @@ const ProblemsList = () => {
           <h1 className="text-3xl font-bold mb-2">문제 리스트</h1>
           <p className="text-gray-400">코딩테스트 문제를 난이도별로 확인하고 도전해보세요</p>
         </section>
+
         <section className="flex flex-col gap-10">
           <section className="mb-6 p-6 bg-gray-900/50 rounded-[10px] border border-gray-800">
             <div className="flex flex-row gap-4 items-center w-full">
-              <FilterSelect>
+              <div className="flex flex-col gap-1 w-1/3">
                 <label htmlFor="category" className="text-base">
-                  카테고리{' '}
+                  카테고리
                 </label>
                 <Select
+                  id="category"
                   className="w-full"
                   title="카테고리"
                   option={categoryCodeOptions}
                   setValue={(value) => setCategoryCode(value)}
                   value={categoryCode}
-                  id="category"
                 />
-              </FilterSelect>
-              <FilterSelect>
+              </div>
+
+              <div className="flex flex-col gap-1 w-1/3">
                 <label htmlFor="difficulty" className="text-base">
-                  난이도{' '}
+                  난이도
                 </label>
                 <Select
                   id="difficulty"
@@ -135,19 +137,19 @@ const ProblemsList = () => {
                   setValue={(value) => setDifficulty(value)}
                   value={difficulty}
                 />
-              </FilterSelect>
+              </div>
 
-              <FilterSelect>
+              <div className="flex flex-col gap-1 w-1/3">
                 <label className="text-base">검색</label>
-                <div className="flex flex-row  w-full gap-5">
+                <div className="flex flex-row w-full gap-5">
                   <input
                     placeholder="문제 제목 또는 번호 검색"
-                    className="text-base border px-2 border-gray-700 rounded h-12  w-full  bg-gray-800"
+                    className="text-base border px-2 border-gray-700 rounded h-12 w-full bg-gray-800"
                     onChange={(e) => setKeyword(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         setSearch(keyword);
-                        setCurrentPage(1);
+                        setCurrentPage(0); // 검색하면 0페이지(첫페이지)로
                       }
                     }}
                   />
@@ -156,7 +158,7 @@ const ProblemsList = () => {
                     aria-label="검색"
                     onClick={() => {
                       setSearch(keyword);
-                      setCurrentPage(1);
+                      setCurrentPage(0); // 검색하면 0페이지로
                     }}
                     label={
                       <svg
@@ -175,9 +177,10 @@ const ProblemsList = () => {
                     }
                   />
                 </div>
-              </FilterSelect>
+              </div>
             </div>
           </section>
+
           {(categoryCode !== '전체' || difficulty !== '전체') && (
             <div
               data-testid="selected-filters"
@@ -220,7 +223,7 @@ const ProblemsList = () => {
           data={data?.content || []}
           isLoading={isLoading}
           currentPage={currentPage}
-          setCurrentPage={setCurrentPage}
+          setCurrentPage={(p) => setCurrentPage(p)}
           totalPages={totalPages}
         />
       </div>

--- a/src/app/(auth)/(navigationsBarLayout)/problems/ui/Table.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/ui/Table.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import React, { useState, useEffect, useMemo } from 'react';
-
 import { useRouter } from 'next/navigation';
 import { SkeletonBox } from '@/shared/ui/loading-indicators';
 import { ProblemsContent } from '@/entities/problems/model/types';
@@ -40,9 +39,9 @@ const getLevelBg = (difficulty: string) => {
 export default function ProblemTable({
   data,
   isLoading,
-  currentPage,
+  currentPage, // 0-based
   setCurrentPage,
-  totalPages,
+  totalPages, // API에서 오는 "페이지 수" (count)
 }: {
   data: ProblemsContent[];
   isLoading: boolean;
@@ -51,65 +50,56 @@ export default function ProblemTable({
   totalPages: number;
 }) {
   const router = useRouter();
-  const [pageGroupStart, setPageGroupStart] = useState(0);
+  const [pageGroupStart, setPageGroupStart] = useState<number>(0); // 0-based group start
   const [myProblemsList, setMyProblemsList] = useState<number[]>([]);
   const { data: myProblems } = useSubmissionList();
   const { data: session } = useSession();
+
   useEffect(() => {
     setMyProblemsList([]);
     if (!session) return;
     if (!myProblems) return;
+    myProblems.result.forEach((item) => setMyProblemsList((prev) => [...prev, item.problemId]));
+  }, [myProblems, session]);
 
-    myProblems.result.map((item) => setMyProblemsList((prev) => [...prev, item.problemId]));
-  }, [myProblems]);
-
+  // currentPage가 page group 범위를 벗어나면 group start 재조정
   useEffect(() => {
     if (currentPage < pageGroupStart || currentPage >= pageGroupStart + PAGE_LIMIT) {
-      setPageGroupStart(Math.floor((currentPage - 1) / PAGE_LIMIT) * PAGE_LIMIT + 1);
+      setPageGroupStart(Math.floor(currentPage / PAGE_LIMIT) * PAGE_LIMIT);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPage]);
+  }, [currentPage, pageGroupStart]);
+
+  // totalPages는 "페이지 수" (count)라고 가정 -> lastIndex = totalPages - 1
+  const lastIndex = Math.max(totalPages - 1, 0);
 
   const pageNumbers = useMemo(() => {
-    // API에서 totalPages를 "실제 페이지 수"로 맞춰온다고 가정
-    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, totalPages);
+    if (totalPages <= 0) return [];
+    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, lastIndex);
     return Array.from({ length: end - pageGroupStart + 1 }, (_, i) => pageGroupStart + i);
-  }, [pageGroupStart, totalPages]);
+  }, [pageGroupStart, totalPages, lastIndex]);
 
-  // const handlePrevGroup = () => {
-  //   if (isLoading || pageGroupStart <= 1) return;
-  //   setPageGroupStart((prev) => prev - PAGE_LIMIT);
-  //   setCurrentPage(pageGroupStart - 1);
-  // };
-
-  // const handleNextGroup = () => {
-  //   if (isLoading || pageGroupStart + PAGE_LIMIT > totalPages) return;
-  //   setPageGroupStart((prev) => prev + PAGE_LIMIT);
-  //   setCurrentPage(pageGroupStart + PAGE_LIMIT);
-  // };
+  // 오른쪽 화살표: 한 그룹 앞으로 (혹은 마지막 인덱스)
   const handleNextPage = () => {
-    if (currentPage < totalPages) {
-      if (currentPage + PAGE_LIMIT > totalPages) {
-        setCurrentPage(totalPages); // 마지막 페이지로 이동
-      } else {
-        setCurrentPage(currentPage + PAGE_LIMIT);
-      }
+    if (pageGroupStart + PAGE_LIMIT <= lastIndex) {
+      setCurrentPage(pageGroupStart + PAGE_LIMIT); // 다음 그룹 시작점
+    } else {
+      setCurrentPage(lastIndex); // 마지막 그룹에서 넘어가면 마지막 페이지로
     }
   };
 
+  // 왼쪽 화살표: 한 그룹 뒤로 (혹은 0)
   const handlePrevPage = () => {
-    if (currentPage > 1) {
-      if (currentPage - PAGE_LIMIT < 1) {
-        setCurrentPage(1);
-      } else {
-        setCurrentPage(currentPage - (currentPage % PAGE_LIMIT || PAGE_LIMIT));
-      }
+    const prevGroupEnd = pageGroupStart - 1;
+    if (prevGroupEnd >= 0) {
+      setCurrentPage(prevGroupEnd); // 이전 그룹의 마지막 페이지
+    } else {
+      setCurrentPage(0); // 이미 첫 그룹이면 첫 페이지
     }
   };
 
   return (
     <div className="flex flex-col">
-      <div className="flex flex-col w-full text-white font-sans bg-gray-900/50 rounded-md  border border-gray-800">
+      <div className="flex flex-col w-full text-white font-sans bg-gray-900/50 rounded-md border border-gray-800">
         <table className="w-full">
           <thead>
             <tr className="border-b border-gray-800 bg-gray-800/50">
@@ -169,7 +159,9 @@ export default function ProblemTable({
                       </td>
                       <td className={`px-6 py-4 text-center text-sm font-medium`}>
                         <span
-                          className={`inline-block px-2 py-1 min-w-[50px] text-xs rounded-md border text-center ${getLevelBg(item.difficulty)} ${getLevelColorClass(item.difficulty)}`}
+                          className={`inline-block px-2 py-1 min-w-[50px] text-xs rounded-md border text-center ${getLevelBg(
+                            item.difficulty
+                          )} ${getLevelColorClass(item.difficulty)}`}
                         >
                           {item.difficulty}
                         </span>
@@ -180,11 +172,6 @@ export default function ProblemTable({
                       <td className="px-6 py-4 text-center text-sm text-gray-300 ">
                         {item.totalSubmissions || 0}건
                       </td>
-                      {/* <td className="px-6 py-4 text-center">
-                      {item.totalSubmissions === 0 || !item.totalSubmissions
-                        ? '0%'
-                        : `${Math.round((item.correctSubmissions / item.totalSubmissions) * 100 * 10) / 10}%`}
-                    </td> */}
                       <td
                         className={`text-center text-sm font-medium ${successRate >= 70 ? 'text-green-400' : successRate >= 40 ? 'text-yellow-400' : 'text-red-400'}`}
                       >
@@ -196,6 +183,7 @@ export default function ProblemTable({
           </tbody>
         </table>
       </div>
+
       {/* 페이지네이션 */}
       <div className="flex justify-center items-center gap-2 mt-4 text-gray-400">
         <Button
@@ -214,25 +202,13 @@ export default function ProblemTable({
         />
 
         {pageNumbers.map((num) => (
-          // <button
-          //   type="button"
-          //   key={num}
-          //   className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition bg-[#6B6B6B] ${
-          //     currentPage === num
-          //       ? 'bg-[#214d35] hover:bg-[#276e48] text-white border-[#214d35]'
-          //       : 'bg-gray-800 border-gray-700 text-white hover:bg-gray-700'
-          //   }`}
-          //   onClick={() => !isLoading && setCurrentPage(num)}
-          // >
-          //   {num}
-          // </button>
           <Button
+            key={num}
             onClick={() => {
               if (!isLoading) setCurrentPage(num);
             }}
-            key={num}
-            label={num + 1}
-            className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition bg-[#6B6B6B] ${
+            label={num + 1} // UI는 1-based로 보여줌
+            className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition ${
               currentPage === num
                 ? 'bg-[#214d35] hover:bg-[#276e48] text-white border-[#214d35]'
                 : 'bg-gray-800 border-gray-700 text-white hover:bg-gray-700'

--- a/src/app/(auth)/(navigationsBarLayout)/problems/ui/Table.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/ui/Table.tsx
@@ -51,7 +51,7 @@ export default function ProblemTable({
   totalPages: number;
 }) {
   const router = useRouter();
-  const [pageGroupStart, setPageGroupStart] = useState(1);
+  const [pageGroupStart, setPageGroupStart] = useState(0);
   const [myProblemsList, setMyProblemsList] = useState<number[]>([]);
   const { data: myProblems } = useSubmissionList();
   const { data: session } = useSession();
@@ -71,7 +71,8 @@ export default function ProblemTable({
   }, [currentPage]);
 
   const pageNumbers = useMemo(() => {
-    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, totalPages - 1); //-1한 이유는 현재 백에서 주는 totalPages가 +1되서 들어옴 예를들어 23페이지까지 데이터가 있으면 totalPages는 24로 들어옴
+    // API에서 totalPages를 "실제 페이지 수"로 맞춰온다고 가정
+    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, totalPages);
     return Array.from({ length: end - pageGroupStart + 1 }, (_, i) => pageGroupStart + i);
   }, [pageGroupStart, totalPages]);
 
@@ -86,24 +87,21 @@ export default function ProblemTable({
   //   setPageGroupStart((prev) => prev + PAGE_LIMIT);
   //   setCurrentPage(pageGroupStart + PAGE_LIMIT);
   // };
-
   const handleNextPage = () => {
-    console.log(totalPages);
-    if (currentPage + 1 < totalPages) {
+    if (currentPage < totalPages) {
       if (currentPage + PAGE_LIMIT > totalPages) {
-        setCurrentPage(totalPages - 1);
+        setCurrentPage(totalPages); // 마지막 페이지로 이동
       } else {
         setCurrentPage(currentPage + PAGE_LIMIT);
       }
     }
   };
+
   const handlePrevPage = () => {
     if (currentPage > 1) {
       if (currentPage - PAGE_LIMIT < 1) {
-        // 맨 앞 범위보다 작아지면 1로
         setCurrentPage(1);
       } else {
-        // 이전 구간의 "끝"으로 이동
         setCurrentPage(currentPage - (currentPage % PAGE_LIMIT || PAGE_LIMIT));
       }
     }
@@ -233,7 +231,7 @@ export default function ProblemTable({
               if (!isLoading) setCurrentPage(num);
             }}
             key={num}
-            label={num}
+            label={num + 1}
             className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition bg-[#6B6B6B] ${
               currentPage === num
                 ? 'bg-[#214d35] hover:bg-[#276e48] text-white border-[#214d35]'


### PR DESCRIPTION

## 🔎 작업 사항

- 문제리스트 api body값 수정(페이지가 1부터 시작하는 이슈 0으로 수정)
<br>


## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 문제 목록과 검색이 항상 첫 페이지(초기 페이지)에서 시작하도록 일관성 있게 조정했습니다.
  - 페이지네이션의 첫/마지막 경계 및 그룹 이동 로직을 수정해 마지막 페이지로 정확히 이동합니다.
  - 페이지 번호 클릭/표시/하이라이트 동작을 일치시키고, 버튼 레이블은 사용자에겐 1부터 보이도록 유지했습니다.

- UI
  - 필터 영역을 3열(카테고리/난이도/검색) 레이아웃으로 재구성하고 관련 제어의 식별자를 추가했습니다.
  - 문제 목록 테이블에서 일부 칼럼을 제거하고 레이아웃·스타일을 소폭 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->