### PR TITLE
feat: 문제 상세 설명에 입출력 예시 추가

### DIFF
--- a/src/entities/problem/api/server/getDetailProblem.type.ts
+++ b/src/entities/problem/api/server/getDetailProblem.type.ts
@@ -16,4 +16,12 @@ export interface IDetailProblemResponse {
   imageUrl: string | null;
   createdAt: string;
   modifiedAt: string;
+  testcases: ITestCase[];
+}
+
+interface ITestCase {
+  id: number;
+  problemId: number;
+  input: string;
+  output: string;
 }

--- a/src/entities/problem/ui/DetailProblem.tsx
+++ b/src/entities/problem/ui/DetailProblem.tsx
@@ -21,6 +21,7 @@ export default function DetailProblem({ detailProblem }: IDetailProblemProps) {
     timeLimit,
     memoryLimit,
     imageUrl,
+    testcases,
   } = detailProblem;
 
   return (
@@ -46,22 +47,50 @@ export default function DetailProblem({ detailProblem }: IDetailProblemProps) {
           </div>
         </div>
       </div>
-      <div className="w-full h-[1px] bg-background" />
+      <hr className="w-full h-[1px] bg-background" />
       <div>
         <FormatMarkdown markdown={description} />
+      </div>
+      <div>
+        <h4 className="text-secondary mt-1">
+          <strong>입출력 예시</strong>
+        </h4>
+        {testcases && testcases.length > 0 && (
+          <>
+            {testcases.map((testCase, idx) => (
+              <div key={testCase.id} className="gap-2 p-4 bg-[#1a2332] rounded-lg w-full">
+                <p>예시 ({idx + 1})</p>
+                <div className="flex gap-4">
+                  <div className="flex flex-1 flex-col gap-2">
+                    <span>입력</span>
+                    <div className="bg-background p-2 rounded-md flex-1 whitespace-pre-wrap break-all">
+                      {testCase.input}
+                    </div>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2">
+                    <span>출력</span>
+                    <div className="bg-background p-2 rounded-md flex-1 whitespace-pre-wrap break-all">
+                      {testCase.output}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </>
+        )}
       </div>
       {imageUrl && (
         <div className="w-full h-60 relative">
           <Image src={imageUrl} alt="문제예시이미지" fill className="object-contain" />
         </div>
       )}
-      <div className="w-full h-[1px] bg-background" />
+      <hr className="w-full h-[1px] bg-background" />
       <div className="flex flex-col gap-4 ">
         <h2 className="text-lg font-semibold mt-3 text-secondary">제한 조건</h2>
         <span>제한시간 : {timeLimit}ms</span>
         <span>메모리 : {memoryLimit}KB</span>
       </div>
-      <div className="w-full h-[1px] bg-background" />
+      <hr className="w-full h-[1px] bg-background" />
 
       <div className="flex flex-col gap-4  text-xs text-gray-400">
         <span>출제 : {creator}</span>


### PR DESCRIPTION
## 🔎 작업 사항

- 문제 상세 페이지에서 입출력 예시를 추가했습니다.
<img width="779" height="377" alt="스크린샷 2025-09-04 오후 7 32 39" src="https://github.com/user-attachments/assets/abf12947-221e-445c-9f74-21d1a46d18f2" />

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 문제 상세 화면에 ‘입출력 예시’ 섹션이 추가되었습니다. 제공되는 경우 각 테스트케이스가 순번과 함께 표시되며, 입력과 출력 블록으로 분리되어 예시를 한눈에 확인할 수 있습니다. 기존 이미지 및 설명 표시 기능은 그대로 유지됩니다.
- 스타일
  - 섹션 간 구분선을 개선(hr 적용)하여 읽기 흐름과 가독성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->