### PR TITLE
[Fix] problem submit & problem git push

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/layout.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/layout.tsx
@@ -1,7 +1,7 @@
 import AuthGuard from '@/lib/AuthGuard';
 import { GlobalFloatingWidget } from '@/widgets/globalFloatingWidget/ui';
 
-export default async function RootLayout({
+export default async function NavigationBarLayout({
   children,
   chatDialog,
 }: Readonly<{

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/page.tsx
@@ -1,15 +1,13 @@
-import { getGitHubUrl } from '@/entities/submitCode/gitpush/actions/getGitHub';
+import { getGitHubUrl } from '@/entities/submitCode';
 import ProblemWorksSection from '@/features/submitCode/submission/ui/ProblemWorksSection';
-import { authOptions } from '@/lib/authOptions';
-import { getServerSession } from 'next-auth';
+import Cookies from 'js-cookie';
 
 interface IProblemPageProps {
   params: Promise<{ problemId: string }>;
 }
 export default async function ProblemPage({ params }: IProblemPageProps) {
   const problemId = (await params).problemId;
-  const session = await getServerSession(authOptions);
-  const accessToken = session?.accessToken;
+  const accessToken = Cookies.get('accessToken');
 
   let githubUrl: string | null = null;
 

--- a/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/[problemId]/page.tsx
@@ -1,23 +1,10 @@
-import { getGitHubUrl } from '@/entities/submitCode';
 import ProblemWorksSection from '@/features/submitCode/submission/ui/ProblemWorksSection';
-import Cookies from 'js-cookie';
 
 interface IProblemPageProps {
   params: Promise<{ problemId: string }>;
 }
 export default async function ProblemPage({ params }: IProblemPageProps) {
   const problemId = (await params).problemId;
-  const accessToken = Cookies.get('accessToken');
 
-  let githubUrl: string | null = null;
-
-  if (accessToken) {
-    try {
-      githubUrl = await getGitHubUrl();
-    } catch (error) {
-      console.error(error);
-    }
-  }
-
-  return <ProblemWorksSection problemId={problemId} githubUrl={githubUrl} />;
+  return <ProblemWorksSection problemId={problemId} />;
 }

--- a/src/entities/submitCode/gitpush/actions/getGitHub.ts
+++ b/src/entities/submitCode/gitpush/actions/getGitHub.ts
@@ -1,9 +1,0 @@
-'use server';
-import ApiHelper from '@/api/client/api';
-import { IMyInfo } from '@/entities/mypage/model/types';
-
-//유저 정보 불러오기 -> git 연동 유무 파악을 위해
-export const getGitHubUrl = async () => {
-  const response = await ApiHelper.get<IMyInfo>('/users', { reqType: 'server' });
-  return response?.data?.result?.githubUrl;
-};

--- a/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
+++ b/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
@@ -2,12 +2,10 @@ import ApiHelper from '@/api/client/api';
 import { API_URL } from '@/api/constants/api.constants';
 import { useQuery } from '@tanstack/react-query';
 import { IGitPushAutoToggleResponse, TGetReposResponse } from './gitpush.query.types';
-import { useSession } from 'next-auth/react';
-
+import Cookies from 'js-cookie';
 /**git push */
 export const useGetGitHubRepo = (githubUrl: string | null) => {
-  const { data: session } = useSession();
-  const accessToken = session?.accessToken?.split(' ')[1] as string;
+  const accessToken = Cookies.get('accessToken');
   return useQuery({
     queryKey: ['get-git-repos'],
     queryFn: async () => {
@@ -20,8 +18,7 @@ export const useGetGitHubRepo = (githubUrl: string | null) => {
 
 /**유저의 gitPush auto 유무를 파악합니다. */
 export const useAutoGitPushStatus = (githubUrl: string | null) => {
-  const { data: session } = useSession();
-  const accessToken = session?.accessToken?.split(' ')[1] as string;
+  const accessToken = Cookies.get('accessToken');
 
   return useQuery({
     queryKey: ['auto-git-push-status'],

--- a/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
+++ b/src/entities/submitCode/gitpush/model/query/gitpush.query.ts
@@ -3,6 +3,7 @@ import { API_URL } from '@/api/constants/api.constants';
 import { useQuery } from '@tanstack/react-query';
 import { IGitPushAutoToggleResponse, TGetReposResponse } from './gitpush.query.types';
 import Cookies from 'js-cookie';
+
 /**git push */
 export const useGetGitHubRepo = (githubUrl: string | null) => {
   const accessToken = Cookies.get('accessToken');

--- a/src/entities/submitCode/index.ts
+++ b/src/entities/submitCode/index.ts
@@ -9,7 +9,6 @@ export type { ISubmissionReviewRequest } from './submission/model/mutation/submi
 export type { ISubmissionReviewResponse } from './submission/model/mutation/submitCode.mutation.type';
 
 /**git push */
-export { getGitHubUrl } from './gitpush/actions/getGitHub';
 export { useGitPushAutoToggleMutation } from './gitpush/model/mutation/gitpush.mutation';
 export { useGitRepoChoice } from './gitpush/model/mutation/gitpush.mutation';
 export { useGetGitHubRepo } from './gitpush/model/query/gitpush.query';

--- a/src/entities/submitCode/submission/model/query/submitCode.query.ts
+++ b/src/entities/submitCode/submission/model/query/submitCode.query.ts
@@ -5,13 +5,12 @@ import { ProblemId } from '@/shared';
 import { useQuery } from '@tanstack/react-query';
 import { ISubmitPrepareData } from './submitCode.query.type';
 import { useProblemWebSocketStoreActions } from '@/features/submitCode/submission/model/useProblemWebSocketStore';
-import { useSession } from 'next-auth/react';
+import Cookies from 'js-cookie';
 
 /**코드 제출시 필요한 세션키, initcaseIds 를 리스폰스로 받음 */
 
 export const useGetSubmitPrepareData = (problemId: ProblemId) => {
-  const { data: session } = useSession();
-  const accessToken = session?.accessToken?.split(' ')[1] as string;
+  const accessToken = Cookies.get('accessToken');
   const { setPrepareData } = useProblemWebSocketStoreActions();
 
   const path = getProblemIdPath(problemId, 'submit-prepare');

--- a/src/features/discussions/reply/ui/Replies.tsx
+++ b/src/features/discussions/reply/ui/Replies.tsx
@@ -5,16 +5,14 @@ import Reply from './Reply';
 import ReplyForm from './ReplyForm';
 import { useRepliesQuery } from '@/entities/discussions';
 import ProtectedBlurBox from '@/shared/ui/LoginRequiredUi/ProtectedBlurBox';
-import { useSession } from 'next-auth/react';
-
+import Cookies from 'js-cookie';
 interface RepliesProps {
   problemId: ProblemId;
   discussionId: number;
 }
 export default function Replies({ problemId, discussionId }: RepliesProps) {
   const queryResult = useRepliesQuery(problemId, discussionId);
-  const { data } = useSession();
-  const token = data?.accessToken;
+  const accessToken = Cookies.get('accessToken');
 
   const repliesData = queryResult?.data?.result;
   const isPending = queryResult?.isPending;
@@ -28,7 +26,7 @@ export default function Replies({ problemId, discussionId }: RepliesProps) {
   }
   return (
     <div className="w-full h-full relative border-t border-primary pt-4 space-y-4 mt-4">
-      {!token && <ProtectedBlurBox />}
+      {!accessToken && <ProtectedBlurBox />}
       <div className="ml-4 flex flex-col gap-4">
         <ReplyForm
           problemId={problemId}

--- a/src/features/submitCode/gitPush/ui/GitPushDialog.tsx
+++ b/src/features/submitCode/gitPush/ui/GitPushDialog.tsx
@@ -14,13 +14,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useEffect, useState } from 'react';
 import { Select } from '@/shared/ui/select/Select';
 
-interface GitPushDialogProps {
-  githubUrl: string | null;
-}
-export default function GitPushDialog({ githubUrl }: GitPushDialogProps) {
+interface GitPushDialogProps {}
+
+export default function GitPushDialog({}: GitPushDialogProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [gitPushStatus, setGitPushStatus] = useState<string | null>(null);
   const [isToolTipOpen, setIsToolTipOpen] = useState<true | undefined>(undefined);
+  const storageData = localStorage.getItem('user-storage');
+  const githubUrl = storageData ? JSON.parse(storageData).state.user.githubUrl : null;
 
   const {
     pushAutoToggle,

--- a/src/features/submitCode/submission/hooks/useConnectProblemWebSocket.ts
+++ b/src/features/submitCode/submission/hooks/useConnectProblemWebSocket.ts
@@ -6,14 +6,12 @@ import { BASE_URL } from '@/constants/env';
 import { sharedStompRef } from '@/shared/lib/stomp/sharedStompRef';
 import { useEffect } from 'react';
 import { useProblemWebSocketStoreActions } from '../model/useProblemWebSocketStore';
-import { useSession } from 'next-auth/react';
-
+import Cookies from 'js-cookie';
 export default function useConnectProblemWebSocket() {
   const problemStompRef = sharedStompRef;
 
   const { clearStore, setIsConnected } = useProblemWebSocketStoreActions();
-  const { data: session } = useSession();
-  const accessToken = session?.accessToken?.split(' ')[1] as string;
+  const accessToken = Cookies.get('accessToken');
 
   useEffect(() => {
     if (!accessToken) {

--- a/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
+++ b/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
@@ -9,11 +9,10 @@ import { fetchSourceCodeData, INITIAL_SOURCE_CODE_DATA } from '@/shared';
 
 interface IProblemWorksSectionProps {
   problemId: string;
-  githubUrl: string | null;
 }
 export type Mode = 'init' | 'result' | 'review';
 
-export default function ProblemWorksSection({ problemId, githubUrl }: IProblemWorksSectionProps) {
+export default function ProblemWorksSection({ problemId }: IProblemWorksSectionProps) {
   const [sourceCodeData, setSourceCodeData] = useState<ISourceCode>(INITIAL_SOURCE_CODE_DATA);
   const [mode, setMode] = useState<Mode>('init');
   const { user } = useUserStore((state) => state);
@@ -41,7 +40,6 @@ export default function ProblemWorksSection({ problemId, githubUrl }: IProblemWo
           sourceCodeData={sourceCodeData}
           setMode={(mode) => setMode(mode)}
           mode={mode}
-          githubUrl={githubUrl}
         />
         <TerminalOutput mode={mode} sourceCodeData={sourceCodeData} problemId={problemId} />
       </div>

--- a/src/features/submitCode/submission/ui/TerminalOutput/CodeResultSummary.tsx
+++ b/src/features/submitCode/submission/ui/TerminalOutput/CodeResultSummary.tsx
@@ -8,6 +8,7 @@ import PendingResultItem from './PendingResultItem';
 export default function CodeResultSummary() {
   const { results, totalResult, isSubmitted, submitPrepareData } = useProblemWebSocketStore();
 
+  console.log('results', totalResult);
   return (
     <div className="flex flex-col gap-4">
       {isSubmitted ? (

--- a/src/features/submitCode/submission/ui/TerminalPanel.tsx
+++ b/src/features/submitCode/submission/ui/TerminalPanel.tsx
@@ -11,8 +11,7 @@ import PanelButton from './PanelButton';
 import { useGetSubmitPrepareData } from '@/entities/submitCode/submission/model/query/submitCode.query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useSubscribeProblem from '../hooks/useSubscribeProblem';
-import { useSession } from 'next-auth/react';
-
+import Cookies from 'js-cookie';
 interface TerminalPanelProps {
   problemId: ProblemId;
   setMode: (mode: Mode) => void;
@@ -30,9 +29,8 @@ export default function TerminalPanel({
 }: TerminalPanelProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const accessToken = Cookies.get('accessToken');
 
-  const { data: session } = useSession();
-  const token = session?.accessToken?.split(' ')[1] as string;
   useGetSubmitPrepareData(problemId);
   const { submitPrepareData } = useProblemWebSocketStore();
 
@@ -46,7 +44,7 @@ export default function TerminalPanel({
   const { clearResults } = useProblemWebSocketStoreActions();
 
   const submitForResult = () => {
-    if (!token) return authGuardTrigger();
+    if (!accessToken) return authGuardTrigger();
     clearResults();
     mutateAsync({ ...sourceCodeData, sessionKey: submitPrepareData.sessionKey || '' });
     setMode('result');

--- a/src/features/submitCode/submission/ui/TerminalPanel.tsx
+++ b/src/features/submitCode/submission/ui/TerminalPanel.tsx
@@ -16,7 +16,6 @@ interface TerminalPanelProps {
   problemId: ProblemId;
   setMode: (mode: Mode) => void;
   mode: Mode;
-  githubUrl: string | null;
   sourceCodeData: ISourceCode;
 }
 
@@ -24,7 +23,6 @@ export default function TerminalPanel({
   problemId,
   setMode,
   mode,
-  githubUrl,
   sourceCodeData,
 }: TerminalPanelProps) {
   const router = useRouter();
@@ -77,7 +75,7 @@ export default function TerminalPanel({
           <Icon.TerminalReviewIcon />
         </PanelButton>
       </div>
-      <GitPushDialog githubUrl={githubUrl} />
+      <GitPushDialog />
     </div>
   );
 }

--- a/src/widgets/globalFloatingWidget/ui/index.tsx
+++ b/src/widgets/globalFloatingWidget/ui/index.tsx
@@ -8,20 +8,19 @@ import Cookies from 'js-cookie';
 import { useEffect, useState } from 'react';
 export function GlobalFloatingWidget() {
   const problemId = usePathname().split('/')[2];
-
-  // const { data: session } = useSession();
-
   const [isLogged, setIsLogged] = useState(false);
   const { data: characterData } = useCheckCharacterQuery(!!isLogged);
 
-  if (problemId) {
-    return null;
-  }
+  const accessToken = Cookies.get('accessToken');
+
   useEffect(() => {
-    if (Cookies.get('accessToken')) {
+    if (accessToken) {
       setIsLogged(true);
     }
-  }, []);
+  }, [accessToken]);
+
+  if (problemId) return null;
+
   return (
     <div className="fixed top-[calc(100vh-15%)] left-[calc(100vw-5%)] flex flex-col gap-2">
       {isLogged && <ChatDialogOpenButton />}


### PR DESCRIPTION
## 🔎 작업 사항

- 토큰 관리 방식 변화로 submit 관련 로직의 토큰 가져오는 부분도 수정했습니다.
- githubUrl 을 userStore 에서 가져오는것으로 변경 했습니다.

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인 상태에서 글로벌 플로팅 위젯에 게임 모달 버튼이 자동으로 표시됩니다.
  - Git Push 대화창이 로컬 저장소에서 GitHub URL을 자동 인식해 사용합니다.

- 리팩터링
  - 인증 체크를 세션 기반에서 쿠키 기반으로 통일해 댓글, 제출, Git Push 흐름의 로그인 가드를 일관화했습니다.
  - 문제 작업 영역과 터미널 패널에서 GitHub URL 전달을 제거하고 내부 조회로 단순화했습니다.
  - 문제 페이지의 서버측 GitHub URL 조회를 제거했습니다.
  - 내비게이션 레이아웃 컴포넌트의 명칭을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->