### PR TITLE
fix : 마이페이지 정보 수정 시 전역변수 user update

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/mypage/tab/Mine.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/tab/Mine.tsx
@@ -22,6 +22,7 @@ import { ModifyForm } from '../ui/ModifyForm';
 import { useQueryClient } from '@tanstack/react-query';
 import { Badge } from '@/shared/ui/badge/Badge';
 import { toast } from 'sonner';
+import { useUserStore } from '@/entities/user/model/store';
 
 export const Mine = () => {
   const queryClient = useQueryClient();
@@ -53,7 +54,7 @@ export const Mine = () => {
   const { mutateAsync: emailVerfiy } = useEmailVerify(BASE_URL || '');
   const { mutateAsync: modify } = useModifyInfo();
   const [languageList, setLanguageList] = useState<{ label: string; value: string }[]>([]);
-
+  const { setUser } = useUserStore();
   const myInfo = data?.data.result;
   const myRanking = ranking?.data.result;
 
@@ -133,7 +134,9 @@ export const Mine = () => {
                     request: body,
                     image: editForm.profileImage ?? undefined,
                   });
-
+                  // setUser()
+                  console.log(response);
+                  setUser(response.result);
                   toast.success(response.message, {
                     richColors: false,
                     style: {

--- a/src/entities/mypage/model/query.ts
+++ b/src/entities/mypage/model/query.ts
@@ -8,6 +8,7 @@ import {
   ILanguages,
   IModifyBody,
   IMyInfo,
+  IUserInfoModifyResponse,
   Ranking,
   Report,
   SubmissionsResonse,
@@ -127,8 +128,7 @@ export const useModifyInfo = () => {
       request: IModifyBody; // 닉네임, 블로그, 깃허브 등 정보
       image?: File; // 프로필 이미지 (선택)
     }) => {
-      console.log('image', image);
-      console.log('request', request);
+
       const formData = new FormData();
 
       // request(JSON) 추가
@@ -139,7 +139,7 @@ export const useModifyInfo = () => {
         formData.append('image', image);
       }
 
-      const response = await ApiHelper.put(API_URL.MYPAGE.USER_INFO, formData, {
+      const response = await ApiHelper.put<IUserInfoModifyResponse>(API_URL.MYPAGE.USER_INFO, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
 

--- a/src/entities/mypage/model/types.ts
+++ b/src/entities/mypage/model/types.ts
@@ -104,3 +104,29 @@ export type IModifyBody = {
   age: number;
   languageId: number | null;
 };
+
+
+
+export interface IUserInfoModifyResponse {
+  age: number;
+  blogUrl: string;
+  email: string;
+  githubUrl: string;
+  introduction: string;
+  language: Language;
+  nickname: string;
+  profileImageUrl: string;
+  tier: string;
+  totalSolvedCount: number;
+  userAuthTypes: string[]
+  userRole: string;
+  username: string;
+  verified: boolean;
+}
+
+export interface Language {
+  id: number;
+  judge0Id: number;
+  name: string;
+  version: string;
+}


### PR DESCRIPTION

## 🔎 작업 사항

- 마이페이지 정보 수정 시 전역변수 user update





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 프로필 수정 후 앱 전반에 사용자 정보가 즉시 갱신되지 않던 문제를 해결하여, 저장 직후 최신 정보와 토스트 알림이 일관되게 표시됩니다.
- 리팩터
  - 프로필 수정 요청/응답 처리 로직을 정교화하여 안정성과 일관성을 개선했습니다.
  - 불필요한 디버그 로그를 제거해 콘솔 가독성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->