### PR TITLE
[feat] 채팅 전송시 스크롤 자동이동 , 채팅 보낸 유저 이름 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,15 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: false, // Strict Mode 비활성화
-  remotePatterns: [
-    {
-      protocol: 'https',
-      hostname: 'ezcode-s3.s3.ap-northeast-2.amazonaws.com',
-      pathname: '/**',
-    },
-  ],
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'ezcode-s3.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
+      },
+    ],
+  },
   webpack(config) {
     // Grab the existing rule that handles SVG imports
     const fileLoaderRule = config.module.rules.find((rule: any) => rule.test?.test?.('.svg'));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,7 @@
   --color-border_primary: #a4a1aa;
 
   --color-gray700: #364153;
+  --color-gray500: #888;
   --color-active: #1e3e2c;
 }
 

--- a/src/features/chat/ui/chatMessage/ChatMessage.tsx
+++ b/src/features/chat/ui/chatMessage/ChatMessage.tsx
@@ -7,19 +7,16 @@ export default function ChatMessage({ msg, userNickname }: IChatMessageProps) {
   const formattedDate = formatDate(msg.time);
 
   return (
-    <li className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
-      <div className={`max-w-[70%] ${isOwn ? 'order-2' : 'order-1'}`}>
-        <p className={`text-sm ${isOwn ? 'text-right' : 'text-left'}`}>{msg.name}</p>
-
-        <div
-          className={`px-4 py-2 rounded-[14px] ${isOwn ? 'bg-primary ' : 'bg-secondary-background '}`}
-        >
-          <p className="whitespace-pre-wrap break-words">{msg.message}</p>
-        </div>
-        <p className={`text-xs text-gray500 mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
-          {formattedDate}
-        </p>
+    <li className={`flex flex-col ${isOwn ? 'items-end' : 'items-start'}`}>
+      <p className={`text-sm ${isOwn ? 'text-right' : 'text-left'}`}>{msg.name}</p>
+      <div
+        className={`max-w-[70%] w-fit px-4 py-2 rounded-[14px] ${isOwn ? ' bg-primary' : ' bg-secondary-background'}`}
+      >
+        <p className="whitespace-pre-wrap break-words">{msg.message}</p>
       </div>
+      <p className={`text-xs text-gray500 mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
+        {formattedDate}
+      </p>
     </li>
   );
 }

--- a/src/features/chat/ui/chatMessage/ChatMessage.tsx
+++ b/src/features/chat/ui/chatMessage/ChatMessage.tsx
@@ -9,14 +9,14 @@ export default function ChatMessage({ msg, userNickname }: IChatMessageProps) {
   return (
     <li className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
       <div className={`max-w-[70%] ${isOwn ? 'order-2' : 'order-1'}`}>
+        <p className={`text-sm ${isOwn ? 'text-right' : 'text-left'}`}>{userNickname}</p>
+
         <div
-          className={`px-4 py-2 rounded-[14px] ${
-            isOwn ? 'bg-[#214d35] text-white' : 'bg-[#1a2332] text-white'
-          }`}
+          className={`px-4 py-2 rounded-[14px] ${isOwn ? 'bg-primary ' : 'bg-secondary-background '}`}
         >
           <p className="whitespace-pre-wrap break-words">{msg.message}</p>
         </div>
-        <p className={`text-xs text-[#888] mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
+        <p className={`text-xs text-gray500 mt-1 ${isOwn ? 'text-right' : 'text-left'}`}>
           {formattedDate}
         </p>
       </div>

--- a/src/features/chat/ui/chatMessage/ChatMessage.tsx
+++ b/src/features/chat/ui/chatMessage/ChatMessage.tsx
@@ -9,7 +9,7 @@ export default function ChatMessage({ msg, userNickname }: IChatMessageProps) {
   return (
     <li className={`flex ${isOwn ? 'justify-end' : 'justify-start'}`}>
       <div className={`max-w-[70%] ${isOwn ? 'order-2' : 'order-1'}`}>
-        <p className={`text-sm ${isOwn ? 'text-right' : 'text-left'}`}>{userNickname}</p>
+        <p className={`text-sm ${isOwn ? 'text-right' : 'text-left'}`}>{msg.name}</p>
 
         <div
           className={`px-4 py-2 rounded-[14px] ${isOwn ? 'bg-primary ' : 'bg-secondary-background '}`}

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -6,6 +6,7 @@ import SystemMessage from '../chatMessage/SystemMessage';
 import ChatMessage from '../chatMessage/ChatMessage';
 import ChatRoomHeader from './ChatRoomHeader';
 import { useMyInfoQuery } from '@/entities/mypage/model/query';
+import { useEffect, useRef } from 'react';
 
 interface ChatProps {
   roomId: number;
@@ -15,6 +16,7 @@ interface ChatProps {
 export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   useJoinChatRoom(roomId);
   const { data } = useMyInfoQuery();
+  const endRef = useRef<HTMLDivElement>(null);
   const nickname = data?.data.result.nickname;
   const { initMessages, realTimeMessages } = useChatWebSocketStore();
   // const { setIsLeaved } = useChatWebSocketActions();
@@ -22,6 +24,12 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   // useEffect(() => {
   //   setIsLeaved(false);
   // }, [roomId]);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [realTimeMessages, initMessages]);
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">
@@ -46,6 +54,7 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
                 })}
               </ul>
             )}
+            <div ref={endRef} />
           </div>
           <ChatInput chatRoomId={roomId} />
         </>

--- a/src/features/chat/ui/chatRoom/index.tsx
+++ b/src/features/chat/ui/chatRoom/index.tsx
@@ -6,6 +6,7 @@ import SystemMessage from '../chatMessage/SystemMessage';
 import ChatMessage from '../chatMessage/ChatMessage';
 import ChatRoomHeader from './ChatRoomHeader';
 import { useMyInfoQuery } from '@/entities/mypage/model/query';
+import { useEffect, useRef } from 'react';
 
 interface ChatProps {
   roomId: number;
@@ -15,6 +16,7 @@ interface ChatProps {
 export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   useJoinChatRoom(roomId);
   const { data } = useMyInfoQuery();
+  const endRef = useRef<HTMLDivElement>(null);
   const nickname = data?.data.result.nickname;
   const { initMessages, realTimeMessages } = useChatWebSocketStore();
   // const { setIsLeaved } = useChatWebSocketActions();
@@ -22,6 +24,20 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
   // useEffect(() => {
   //   setIsLeaved(false);
   // }, [roomId]);
+
+  // 방이 바뀔 때(입장) 즉시 하단으로 이동
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'instant' });
+    }
+  }, [roomId, initMessages]);
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [realTimeMessages]);
 
   return (
     <section className="w-full flex h-full flex-col justify-center flex-4/5">
@@ -46,6 +62,7 @@ export default function ChatRoom({ roomId, roomTitle }: ChatProps) {
                 })}
               </ul>
             )}
+            <div ref={endRef} />
           </div>
           <ChatInput chatRoomId={roomId} />
         </>


### PR DESCRIPTION
## 🔎 작업 사항
* 채팅이 쌓여있는 방에 들어오거나, 채팅을 보냈을때 자동으로 가장 밑의 스크롤로 이동 합니다.
* 채팅을 보낸 유저의 이름을 표시합니다.
* 
<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 채팅방이 새 메시지 도착/초기 로드 시 자동으로 하단으로 스크롤됩니다.
  - 메시지 버블 위에 발신자 닉네임이 표시됩니다.

- 스타일
  - 메시지 배경색을 의미 기반 색상 토큰으로 정리하고, 타임스탬프 색상을 회색 토큰으로 통일했습니다.
  - 전역 테마에 회색 색상 토큰(gray500)을 추가했습니다.

- 정리/관리
  - 이미지 관련 구성 구조를 재배치하여 설정 호환성과 유지보수성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->