### PR TITLE
 localstorage에 있는 git url 들고오는 코드 이슈 수정, 문제풀이 페이지 토론 정렬 방…

### DIFF
--- a/src/features/discussions/disussions/ui/Discussions.tsx
+++ b/src/features/discussions/disussions/ui/Discussions.tsx
@@ -30,8 +30,7 @@ export default function Discussions({ problemId }: IDiscussionProps) {
     { label: '인기순', value: '인기순' },
     { label: '최신순', value: '최신순' },
     { label: '추천순', value: '추천순' },
-  ];
-
+  ] as const;
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       if (entries[0].isIntersecting && hasNextPage) {
@@ -87,7 +86,7 @@ export default function Discussions({ problemId }: IDiscussionProps) {
           <p>토론 목록을 불러오는데 실패했습니다.</p>
         ) : (
           <div className="flex flex-col w-full">
-            <Select
+            {/* <Select
               option={sortOptions}
               title="정렬"
               value={params.sort}
@@ -95,7 +94,21 @@ export default function Discussions({ problemId }: IDiscussionProps) {
                 const typedValue = value as sortType;
                 setParams((prev) => ({ ...prev, sort: typedValue, sortBy: typedValue }));
               }}
-            />
+            /> */}
+            <div className="flex flex-row gap-1">
+              {sortOptions.map((item) => {
+                return (
+                  <span
+                    className={`${item.value === params.sort ? `text-secondary` : ``}`}
+                    onClick={() => {
+                      setParams((prev) => ({ ...prev, sort: item.label, sortBy: item.label }));
+                    }}
+                  >
+                    {item.label}
+                  </span>
+                );
+              })}
+            </div>
             {discussions.length < 1 ? (
               <div className="flex justify-center text-[#ccc] mt-3">
                 아직 해당문제의 토론글이 없습니다.


### PR DESCRIPTION

## 🔎 작업 사항

-  localstorage에 있는 git url 들고오는 코드 이슈 수정
- 문제풀이 페이지 토론 정렬 방식 select -> 버튼 선택


## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 토론 목록의 정렬 UI가 드롭다운 대신 인라인 라벨 형태로 개선되었습니다. 사용자는 라벨을 클릭해 정렬 방식과 기준을 즉시 전환할 수 있습니다.
  * 기존의 무한 스크롤과 데이터 로딩 동작은 그대로 유지되며, 목록 상태에 따라 조건부 렌더링도 동일하게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->