### PR TITLE
Refactoring/code history

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-query-devtools": "^5.81.2",
     "@types/js-cookie": "^3.0.6",
+    "@types/lodash.debounce": "^4.0.9",
     "@uiw/react-codemirror": "^4.23.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "js-cookie": "^3.0.5",
+    "lodash.debounce": "^4.0.8",
     "lucide-react": "^0.515.0",
     "next": "15.3.3",
     "next-auth": "^4.24.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
+      '@types/lodash.debounce':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@uiw/react-codemirror':
         specifier: ^4.23.14
         version: 4.25.1(@babel/runtime@7.28.2)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.11.2)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.1)(codemirror@6.0.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1991,6 +1994,12 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash.debounce@4.0.9':
+    resolution: {integrity: sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -7177,6 +7186,12 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/lodash.debounce@4.0.9':
+    dependencies:
+      '@types/lodash': 4.17.20
+
+  '@types/lodash@4.17.20': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
+      lodash.debounce:
+        specifier: ^4.0.8
+        version: 4.0.8
       lucide-react:
         specifier: ^0.515.0
         version: 0.515.0(react@19.1.1)

--- a/src/entities/submitCode/submission/model/query/submitCode.query.ts
+++ b/src/entities/submitCode/submission/model/query/submitCode.query.ts
@@ -5,12 +5,10 @@ import { ProblemId } from '@/shared';
 import { useQuery } from '@tanstack/react-query';
 import { ISubmitPrepareData } from './submitCode.query.type';
 import { useProblemWebSocketStoreActions } from '@/features/submitCode/submission/model/useProblemWebSocketStore';
-import Cookies from 'js-cookie';
 
 /**코드 제출시 필요한 세션키, initcaseIds 를 리스폰스로 받음 */
 
-export const useGetSubmitPrepareData = (problemId: ProblemId) => {
-  const accessToken = Cookies.get('accessToken');
+export const useGetSubmitPrepareData = (problemId: ProblemId, hasAccessToken: boolean) => {
   const { setPrepareData } = useProblemWebSocketStoreActions();
 
   const path = getProblemIdPath(problemId, 'submit-prepare');
@@ -31,6 +29,6 @@ export const useGetSubmitPrepareData = (problemId: ProblemId) => {
         return { sessionKey: null, testcaseIds: null };
       }
     },
-    enabled: !!accessToken,
+    enabled: hasAccessToken,
   });
 };

--- a/src/features/submitCode/submission/ui/CodeEditor.tsx
+++ b/src/features/submitCode/submission/ui/CodeEditor.tsx
@@ -8,18 +8,46 @@ import {
   SOURCECODE,
 } from '@/shared';
 import { Select } from '@/shared/ui/select/Select';
+import { useEffect } from 'react';
+import { useAutoSave } from '@/shared/util/saveLocalStorage';
+import { ISourceCode } from '@/entities/submitCode';
 
 interface ICodeEditorProps {
   onChangeSourceCodeData: (key: 'sourceCode' | 'languageId', value: number | string) => void;
-  languageId: number;
+  sourceCodeData: ISourceCode;
+  problemId: string;
 }
-export default function CodeEditor({ onChangeSourceCodeData, languageId }: ICodeEditorProps) {
-  const handleChangeLanguage = (value: string) => {
-    const languageId = Number(value); //select option required only string type value ㅠ
+export default function CodeEditor({
+  onChangeSourceCodeData,
+  sourceCodeData,
+  problemId,
+}: ICodeEditorProps) {
+  const { languageId } = sourceCodeData;
 
+  const debouncedSave = useAutoSave(2000);
+
+  const handleChangeLanguage = (value: string) => {
+    const languageId = Number(value);
+    debouncedSave(`sourceCodeData-${problemId}`, {
+      sourceCode: SOURCECODE[languageId],
+      languageId: languageId,
+    });
     onChangeSourceCodeData('languageId', languageId);
     onChangeSourceCodeData('sourceCode', SOURCECODE[languageId]);
   };
+
+  const handleChangeCode = (value: string) => {
+    onChangeSourceCodeData('sourceCode', value);
+  };
+
+  useEffect(() => {
+    if (sourceCodeData.sourceCode !== SOURCECODE[languageId]) {
+      debouncedSave(`sourceCodeData-${problemId}`, {
+        sourceCode: sourceCodeData.sourceCode,
+        languageId: languageId,
+      });
+    }
+  }, [sourceCodeData.sourceCode]);
 
   return (
     <section className="flex-1 flex flex-col h-full gap-4">
@@ -29,11 +57,12 @@ export default function CodeEditor({ onChangeSourceCodeData, languageId }: ICode
         option={LANGUAGE_SELECTOR_OPTIONS}
         setValue={(value) => handleChangeLanguage(value)}
       />
+
       <CodeMirror
         basicSetup={CodeMirrorBasicSetup}
-        value={SOURCECODE[languageId]}
+        value={sourceCodeData.sourceCode}
         theme={'dark'}
-        onChange={(value) => onChangeSourceCodeData('sourceCode', value)}
+        onChange={(value) => handleChangeCode(value)}
         extensions={[CODEMIRROR_EXTENSIONS[languageId]]}
         aria-autocomplete="none"
         autoCapitalize="off"

--- a/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
+++ b/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
@@ -5,7 +5,7 @@ import TerminalOutput from './TerminalOutput';
 import TerminalPanel from './TerminalPanel';
 import { ISourceCode } from '@/entities/submitCode';
 import { useUserStore } from '@/entities/user/model/store';
-import { fetchSourceCodeData, INITIAL_SOURCE_CODE_DATA } from '@/shared';
+import { fetchSourceCodeData, INITIAL_SOURCE_CODE_DATA, SOURCECODE } from '@/shared';
 
 interface IProblemWorksSectionProps {
   problemId: string;
@@ -23,20 +23,27 @@ export default function ProblemWorksSection({ problemId }: IProblemWorksSectionP
 
   useEffect(() => {
     if (!user) return;
+    const storedData = localStorage.getItem(`sourceCodeData-${problemId}`);
 
     const fetchedSourceCodeData = fetchSourceCodeData(user?.language?.id as number);
+    if (
+      storedData &&
+      JSON.parse(storedData).sourceCode !== SOURCECODE[JSON.parse(storedData).languageId]
+    )
+      return;
     setSourceCodeData(fetchedSourceCodeData);
   }, [user?.language, user]);
 
   useEffect(() => {
     const storedData = localStorage.getItem(`sourceCodeData-${problemId}`);
+
     setSourceCodeData(
       storedData ? (JSON.parse(storedData) as ISourceCode) : INITIAL_SOURCE_CODE_DATA
     );
     if (!storedData) {
       localStorage.setItem(`sourceCodeData-${problemId}`, JSON.stringify(sourceCodeData));
     }
-  }, []);
+  }, [problemId]);
 
   return (
     <section className="flex flex-col gap-5 h-full">

--- a/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
+++ b/src/features/submitCode/submission/ui/ProblemWorksSection.tsx
@@ -28,11 +28,22 @@ export default function ProblemWorksSection({ problemId }: IProblemWorksSectionP
     setSourceCodeData(fetchedSourceCodeData);
   }, [user?.language, user]);
 
+  useEffect(() => {
+    const storedData = localStorage.getItem(`sourceCodeData-${problemId}`);
+    setSourceCodeData(
+      storedData ? (JSON.parse(storedData) as ISourceCode) : INITIAL_SOURCE_CODE_DATA
+    );
+    if (!storedData) {
+      localStorage.setItem(`sourceCodeData-${problemId}`, JSON.stringify(sourceCodeData));
+    }
+  }, []);
+
   return (
     <section className="flex flex-col gap-5 h-full">
       <CodeEditor
+        problemId={problemId}
+        sourceCodeData={sourceCodeData}
         onChangeSourceCodeData={handleChangeSourceCodeData}
-        languageId={sourceCodeData.languageId}
       />
       <div className="flex flex-1 flex-col bg-secondary-background rounded-[10px] shadow-lg ">
         <TerminalPanel

--- a/src/features/submitCode/submission/ui/TerminalPanel.tsx
+++ b/src/features/submitCode/submission/ui/TerminalPanel.tsx
@@ -29,7 +29,7 @@ export default function TerminalPanel({
   const searchParams = useSearchParams();
   const accessToken = Cookies.get('accessToken');
 
-  useGetSubmitPrepareData(problemId);
+  useGetSubmitPrepareData(problemId, !!accessToken);
   const { submitPrepareData } = useProblemWebSocketStore();
 
   const authGuardTrigger = () => {

--- a/src/shared/util/saveLocalStorage.ts
+++ b/src/shared/util/saveLocalStorage.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import debounce from 'lodash.debounce';
+
+export type AutoSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+type SetStatusType = (status: AutoSaveStatus) => void;
+
+/**@param delay- debounce 딜레이 */
+/**로컬스토리지 자동 저장 훅 */
+export function useAutoSave(delay = 2000) {
+  const debouncedSave = useMemo(
+    () =>
+      debounce((key: string, value: unknown, setStatus?: SetStatusType) => {
+        try {
+          setStatus?.('saving');
+          const serializedValue = JSON.stringify(value);
+          localStorage.setItem(key, serializedValue);
+          setStatus?.('saved');
+        } catch (err) {
+          setStatus?.('error');
+        }
+      }, delay),
+    [delay]
+  );
+
+  return debouncedSave;
+}


### PR DESCRIPTION
## 🔎 작업 사항

- 문제별 코드 기록 브라우져 저장 
- 로그인 이전에 소스코드를 작성한 내용이 있으면 (언어별 defaultSourceCode와 다르면) 유저가 자주사용하는 언어가 등록되어있더라도 브라우져 기록을 먼저 따르게끔 구현

<br>

## ❗️ 전달 사항
npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 코드 편집기에 자동 저장 기능 추가

* **개선 사항**
  * 작성한 코드가 로컬 스토리지에 자동 저장되고 복구 가능
  * 코드 언어 변경 시 자동 저장 처리
  * 제출 기능의 인증 토큰 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->