### PR TITLE
fix : 난이도 카테고리 변경 시 페이지 초기화

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/problems/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import ProblemTable from './ui/Table';
 import { useProblemListQuery } from '@/entities/problems/model/query';
@@ -97,6 +97,9 @@ const ProblemsList = () => {
 
   const totalPages = data?.totalPages ?? 0;
 
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [categoryCode, difficulty]);
   return (
     <div className="flex flex-col px-10 py-18 w-full gap-4 justify-center items-center">
       <div className="flex flex-col max-w-[1600px] w-full gap-6">


### PR DESCRIPTION

## 🔎 작업 사항

-난이도 카테고리 변경 시 페이지 초기화




## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* **필터 변경 시 페이지 번호 자동 초기화**: 카테고리 또는 난이도 필터를 변경할 때 자동으로 첫 번째 페이지로 돌아갑니다. 필터 변경 후 올바른 검색 결과를 확인할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->