### PR TITLE
feat: 알림 페이지의 페이지 네이션

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/mypage/SideNavigation.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/SideNavigation.tsx
@@ -2,20 +2,19 @@
 
 import Password from './../../../../../public/icons/mypage/password.svg';
 import Image from 'next/image';
-import { User, MessageSquare, Flag, History } from 'lucide-react';
+import { User, Flag, History } from 'lucide-react';
 
 interface IProps {
   tab: string;
   setTab: (tab: string) => void;
   authType: string[];
 }
-type MenuItem = 'mine' | 'solved' | 'inquiry' | 'report' | 'password';
+type MenuItem = 'mine' | 'solved' | 'report' | 'password';
 export const SideNavigation = ({ tab, setTab, authType }: IProps) => {
   const menuItems = [
     { id: 'mine' as MenuItem, label: '내 정보 확인', icon: User },
     { id: 'report' as MenuItem, label: '신고', icon: Flag },
     { id: 'solved' as MenuItem, label: '문제 푼 기록', icon: History },
-    { id: 'inquiry' as MenuItem, label: '문의하기', icon: MessageSquare },
   ];
   const bottomMenuItem = [{ id: 'password' as MenuItem, label: '비밀번호 변경', icon: Password }];
   return (

--- a/src/app/(auth)/(navigationsBarLayout)/mypage/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/page.tsx
@@ -4,7 +4,6 @@ import { SideNavigation } from './SideNavigation';
 import { Mine } from './tab/Mine';
 import { Solved } from './tab/Solved';
 import { Report } from './tab/Report';
-import { Inquiry } from './tab/Inquiry';
 import { ChangePassword } from './tab/ChangePassword';
 import { useMyInfoQuery } from '@/entities/mypage/model/query';
 
@@ -16,14 +15,12 @@ const Mypage = () => {
     mine: <Mine />,
     solved: <Solved />,
     report: <Report />,
-    inquiry: <Inquiry />,
   } as const;
 
   // 소셜로그인은 비밀번호 변경 탭 안보이게
   const tabComponents = data?.data.result.userAuthTypes.includes('EMAIL')
     ? { ...baseTabs, password: <ChangePassword /> }
     : baseTabs;
-  console.log(data);
   return (
     <div className="w-full  flex h-full">
       <SideNavigation tab={tab} setTab={setTab} authType={data?.data.result?.userAuthTypes || []} />

--- a/src/app/(auth)/(navigationsBarLayout)/mypage/tab/ChangePassword.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/tab/ChangePassword.tsx
@@ -7,7 +7,6 @@ import { Button } from '@/shared/ui/button/Button';
 import { toast } from 'sonner';
 
 export const ChangePassword = () => {
-  console.log('hi');
   const [passwordForm, setPasswordForm] = useState<{
     currentPassword: string;
     newPassword: string;
@@ -54,7 +53,7 @@ export const ChangePassword = () => {
       <section className="rounded-lg flex flex-col gap-8 border bg-gray-900/50 border-gray-700/50 p-10">
         <div className="flex flex-row gap-4 items-center">
           <Image src={Password} alt="password" width={30} height={30} />
-          <h1 className="text-2xl leading-0 font-bold">문제 풀이 기록</h1>
+          <h1 className="text-2xl leading-0 font-bold">비밀번호 변경</h1>
         </div>
         <div className="max-w-md space-y-4">
           {/* 현재 비밀번호 */}

--- a/src/app/(auth)/(navigationsBarLayout)/mypage/tab/Inquiry.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/tab/Inquiry.tsx
@@ -1,3 +1,0 @@
-export const Inquiry = () => {
-  return <div></div>;
-};

--- a/src/app/(auth)/(navigationsBarLayout)/mypage/ui/Heatmap.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/ui/Heatmap.tsx
@@ -99,6 +99,8 @@ export const Heatmap = ({ data }: { data: IHeatmapItem[] }) => {
         title=""
         value={tab}
         setValue={(value) => setTab(value)}
+        size="sm"
+        className="absolute -top-15 right-15"
       />
     </div>
   );

--- a/src/app/(auth)/(navigationsBarLayout)/notifications/page.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/notifications/page.tsx
@@ -1,19 +1,27 @@
 'use client';
 
 import { Bell } from 'lucide-react';
-import { useReadNotification } from '@/entities/notifications/query';
+import { useGetNotifications, useReadNotification } from '@/entities/notifications/query';
 import { moveToNotificationPath } from '@/features/alarm/hooks/moveToNotificationPath';
 import { Notification } from '@/features/alarm/model/store.types';
 import { useRouter } from 'next/navigation';
-import ApiHelper from '@/api/client/api';
-import { API_URL } from '@/api/constants/api.constants';
 import useNotificationsStore from '@/features/alarm/model/store';
+import Pagination from '@/widgets/pagination';
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function Notifications() {
+  const [currentPage, setCurrentPage] = useState<number>(0);
   const { mutateAsync: readNotification } = useReadNotification();
-  const { notifications } = useNotificationsStore();
+  const { notifications, isConnected } = useNotificationsStore();
   const router = useRouter();
 
+  const notificationQuery = useQueryClient();
+  const { isLoading } = useGetNotifications(currentPage, isConnected);
+
+  const totalPages = notifications
+    ? Math.ceil(notifications.totalElements / notifications.size)
+    : 0;
   const totalNotifications = notifications?.content.filter((n) => !n.isRead).length || 0;
 
   const handleClickNotification = async (notification: Notification) => {
@@ -21,13 +29,13 @@ export default function Notifications() {
     moveToNotificationPath(notificationType, payload.problemId, payload.discussionId, router);
     if (isRead) return;
     await readNotification(id);
-    ApiHelper.get(API_URL.NOTIFICATIONS);
+    notificationQuery.invalidateQueries({ queryKey: ['notifications', currentPage] });
   };
 
   const handleMarkAllAsRead = async () => {
     const unreadNotifications = notifications.content.filter((n) => !n.isRead);
     await Promise.all(unreadNotifications.map((n) => readNotification(n.id)));
-    ApiHelper.get(API_URL.NOTIFICATIONS);
+    notificationQuery.invalidateQueries({ queryKey: ['notifications', currentPage] });
   };
 
   return (
@@ -119,6 +127,12 @@ export default function Notifications() {
               </button>
             </div>
           )}
+          <Pagination
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            totalPages={totalPages}
+            isLoading={isLoading}
+          />
         </section>
       </div>
     </div>

--- a/src/entities/notifications/query.ts
+++ b/src/entities/notifications/query.ts
@@ -1,6 +1,6 @@
 import ApiHelper from '@/api/client/api';
 import { API_URL } from '@/api/constants/api.constants';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 export const useReadNotification = () => {
   return useMutation({
@@ -9,5 +9,19 @@ export const useReadNotification = () => {
 
       return result;
     },
+  });
+};
+export const useGetNotifications = (page: number, isWebSocketConnected: boolean) => {
+  return useQuery({
+    queryKey: ['notifications', page],
+    queryFn: async () => {
+      const result = await ApiHelper.get(
+        `${API_URL.NOTIFICATIONS}?pageable=page&page=${page}&size=5`
+      );
+
+      return result;
+    },
+    enabled: isWebSocketConnected,
+    staleTime: 0,
   });
 };

--- a/src/entities/problems/ui/table/ProblemTable.tsx
+++ b/src/entities/problems/ui/table/ProblemTable.tsx
@@ -1,16 +1,14 @@
 'use client';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { ProblemsContent } from '@/entities/problems/model/types';
 import { useMyDailySolved } from '@/entities/mypage/model/query';
-import { CheckCircle, ChevronLeft, ChevronRight } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { CheckCircle } from 'lucide-react';
 import Cookies from 'js-cookie';
 import { LevelUtil } from '@/shared/util/levelUtil';
 import TableHead from '@/entities/problems/ui/table/TableHead';
 import TableSkeleton from './TableSkeleton';
-
-const PAGE_LIMIT = 15;
+import Pagination from '@/widgets/pagination';
 
 export default function ProblemTable({
   data,
@@ -26,7 +24,6 @@ export default function ProblemTable({
   totalPages: number;
 }) {
   const router = useRouter();
-  const [pageGroupStart, setPageGroupStart] = useState<number>(0); // 0-based group start
   const [myProblemsList, setMyProblemsList] = useState<number[]>([]);
   const { data: myProblems } = useMyDailySolved();
   const token = Cookies.get('accessToken');
@@ -41,45 +38,6 @@ export default function ProblemTable({
     );
     setMyProblemsList(solved); // 하나의 배열에 담김
   }, [myProblems, token]);
-
-  useEffect(() => {
-    console.log(myProblemsList);
-  }, [myProblemsList]);
-
-  // currentPage가 page group 범위를 벗어나면 group start 재조정
-  useEffect(() => {
-    if (currentPage < pageGroupStart || currentPage >= pageGroupStart + PAGE_LIMIT) {
-      setPageGroupStart(Math.floor(currentPage / PAGE_LIMIT) * PAGE_LIMIT);
-    }
-  }, [currentPage, pageGroupStart]);
-
-  // totalPages는 "페이지 수" (count)라고 가정 -> lastIndex = totalPages - 1
-  const lastIndex = Math.max(totalPages - 1, 0);
-
-  const pageNumbers = useMemo(() => {
-    if (totalPages <= 0) return [];
-    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, lastIndex);
-    return Array.from({ length: end - pageGroupStart + 1 }, (_, i) => pageGroupStart + i);
-  }, [pageGroupStart, totalPages, lastIndex]);
-
-  // 오른쪽 화살표: 한 그룹 앞으로 (혹은 마지막 인덱스)
-  const handleNextPage = () => {
-    if (pageGroupStart + PAGE_LIMIT <= lastIndex) {
-      setCurrentPage(pageGroupStart + PAGE_LIMIT); // 다음 그룹 시작점
-    } else {
-      setCurrentPage(lastIndex); // 마지막 그룹에서 넘어가면 마지막 페이지로
-    }
-  };
-
-  // 왼쪽 화살표: 한 그룹 뒤로 (혹은 0)
-  const handlePrevPage = () => {
-    const prevGroupEnd = pageGroupStart - 1;
-    if (prevGroupEnd >= 0) {
-      setCurrentPage(prevGroupEnd); // 이전 그룹의 마지막 페이지
-    } else {
-      setCurrentPage(0); // 이미 첫 그룹이면 첫 페이지
-    }
-  };
 
   return (
     <div className="flex flex-col">
@@ -103,26 +61,24 @@ export default function ProblemTable({
                 return (
                   <tr
                     key={item.id}
-                    className={`border-b border-gray-800/50 hover:bg-white/[0.08] transition-colors duration-200 cursor-pointer ${
-                      isSolved ? 'bg-[#214d35]/10 border-l-4 border-l-[#00d084]' : ''
+                    className={`border-b border-gray-800/50 hover:bg-white/8 transition-colors duration-200 cursor-pointer ${
+                      isSolved ? 'bg-primary/10 border-l-4 border-l-secondary' : ''
                     }`}
                     onClick={() => router.push(`/problems/${item.id}`)}
                   >
                     <td className="px-6 py-4 text-sm text-center text-gray-300">{item.id}</td>
                     <td className="px-6 py-4">
                       <div className="flex flex-row gap-4 justify-center items-center">
-                        {isSolved && (
-                          <CheckCircle className="w-4 h-4 text-[#00d084] flex-shrink-0" />
-                        )}
+                        {isSolved && <CheckCircle className="w-4 h-4 text-secondary shrink-0" />}
                         <div>
-                          <div className="text-center text-sm font-medium text-white hover:text-[#00d084] transition-colors">
+                          <div className="text-center text-sm font-medium text-white hover:text-secondary transition-colors">
                             {item.title}
                           </div>
                           <div className="text-center text-xs text-gray-400 mt-1">{categories}</div>
                         </div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 text-center text-sm text-[#00d084] font-medium">
+                    <td className="px-6 py-4 text-center text-sm text-secondary font-medium">
                       {item.score}
                     </td>
                     <td className={`px-6 py-4 text-center text-sm font-medium`}>
@@ -153,36 +109,12 @@ export default function ProblemTable({
         </table>
       </div>
 
-      {/* 페이지네이션 */}
-      <div className="flex justify-center items-center gap-2 mt-4 text-gray-400">
-        <Button
-          onClick={handlePrevPage}
-          className="p-1 bg-[#214d35] hover:bg-[#276e48] disabled:opacity-50 disabled:cursor-not-allowed rounded-[10px] w-10 h-10"
-        >
-          <ChevronLeft className="w-4 h-4" />
-        </Button>
-        {pageNumbers.map((num) => (
-          <Button
-            key={num}
-            onClick={() => {
-              if (!isLoading) setCurrentPage(num);
-            }}
-            className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition ${
-              currentPage === num
-                ? 'bg-[#214d35] hover:bg-[#276e48] text-white border-[#214d35]'
-                : 'bg-gray-800 border-gray-700 text-white hover:bg-gray-700'
-            }`}
-          >
-            {num + 1}
-          </Button>
-        ))}
-        <Button
-          onClick={handleNextPage}
-          className="p-1 bg-[#214d35] hover:bg-[#276e48] disabled:opacity-50 disabled:cursor-not-allowed rounded-[10px] w-10 h-10"
-        >
-          <ChevronRight className="w-4 h-4" />
-        </Button>
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        setCurrentPage={setCurrentPage}
+        totalPages={totalPages}
+        isLoading={isLoading}
+      />
     </div>
   );
 }

--- a/src/features/alarm/hooks/useNotificationWebSocket.ts
+++ b/src/features/alarm/hooks/useNotificationWebSocket.ts
@@ -5,8 +5,6 @@ import { Client } from '@stomp/stompjs';
 
 import { useEffect, useRef } from 'react';
 import SockJS from 'sockjs-client';
-import ApiHelper from '@/api/client/api';
-import { API_URL } from '@/api/constants/api.constants';
 import Cookies from 'js-cookie';
 import { useNotificationsActions } from '../model/store';
 
@@ -14,7 +12,7 @@ export default function useConnectAlarmWebSocket() {
   const alarmStompRef = useRef<Client | null>(null);
   const accessToken = Cookies.get('accessToken');
 
-  const { setNotification, setRealTimeNotification } = useNotificationsActions();
+  const { setNotification, setRealTimeNotification, setIsConnected } = useNotificationsActions();
 
   useEffect(() => {
     if (!accessToken) {
@@ -36,7 +34,7 @@ export default function useConnectAlarmWebSocket() {
       heartbeatOutgoing: 10000, // 10초마다 클라이언트 -> 서버 ping 전송
       onConnect: () => {
         console.log('✅ Alarm WebSocket connected');
-
+        setIsConnected(true);
         client.subscribe('/user/queue/notification', (message) => {
           try {
             const body = JSON.parse(message.body);
@@ -55,7 +53,7 @@ export default function useConnectAlarmWebSocket() {
           }
         });
 
-        ApiHelper.get(API_URL.NOTIFICATIONS);
+        // ApiHelper.get(API_URL.NOTIFICATIONS);
       },
       onStompError: (frame) => {
         console.error('❌ STOMP Error', frame);
@@ -69,6 +67,7 @@ export default function useConnectAlarmWebSocket() {
     // 언마운트 시 정리
     return () => {
       console.log('🔌 Cleaning up Alarm STOMP client');
+      setIsConnected(false);
       client.deactivate();
       alarmStompRef.current = null;
     };

--- a/src/features/alarm/model/store.ts
+++ b/src/features/alarm/model/store.ts
@@ -20,9 +20,14 @@ const useNotificationsStore = create<INotificationsStore>()(
             notifications: {
               ...state.notifications,
               content: [newNotification, ...state.notifications.content],
-              totalElement: state.notifications.totalElement + 1,
+              totalElements: state.notifications.totalElements + 1,
             },
           };
+        });
+      },
+      setIsConnected: (isConnected: boolean) => {
+        set({
+          isConnected,
         });
       },
     },
@@ -35,6 +40,7 @@ export function useNotificationsActions() {
     useShallow((state) => ({
       setNotification: state.actions.setNotification,
       setRealTimeNotification: state.actions.setRealTimeNotification,
+      setIsConnected: state.actions.setIsConnected,
     }))
   );
 }

--- a/src/features/alarm/model/store.types.ts
+++ b/src/features/alarm/model/store.types.ts
@@ -25,11 +25,12 @@ export interface INotifications {
   content: Notification[];
   page: number;
   size: number;
-  totalElement: number;
+  totalElements: number;
 }
 /** 스토어 상태 인터페이스 */
 export interface INotificationStoreState {
   notifications: INotifications;
+  isConnected: boolean;
 }
 
 export const INITIAL_STATE = {
@@ -37,8 +38,9 @@ export const INITIAL_STATE = {
     content: [],
     page: 0,
     size: 10,
-    totalElement: 0,
+    totalElements: 0,
   },
+  isConnected: false,
 };
 
 /** 스토어 액션 인터페이스 */
@@ -46,6 +48,7 @@ interface INotificationStoreAction {
   actions: {
     setNotification: (notifications: INotifications) => void;
     setRealTimeNotification: (newNotification: Notification) => void;
+    setIsConnected: (isConnected: boolean) => void;
   };
 }
 

--- a/src/widgets/NavigationBar/ui/Notifications.tsx
+++ b/src/widgets/NavigationBar/ui/Notifications.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import ApiHelper from '@/api/client/api';
-import { API_URL } from '@/api/constants/api.constants';
-import { useReadNotification } from '@/entities/notifications/query';
+import { useGetNotifications, useReadNotification } from '@/entities/notifications/query';
 import { moveToNotificationPath } from '@/features/alarm/hooks/moveToNotificationPath';
 import useConnectAlarmWebSocket from '@/features/alarm/hooks/useNotificationWebSocket';
 import Image from 'next/image';
@@ -10,16 +8,19 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Notification } from '@/features/alarm/model/store.types';
 import useNotificationsStore from '@/features/alarm/model/store';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function Notifications() {
   useConnectAlarmWebSocket();
   const router = useRouter();
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
-  const { notifications } = useNotificationsStore();
+  const { notifications, isConnected } = useNotificationsStore();
   const { mutateAsync: readNotification } = useReadNotification();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const unreadCount = notifications.content.filter((n) => !n.isRead).length;
+  useGetNotifications(0, isConnected);
+  const notificationQuery = useQueryClient();
 
   const handleViewAll = () => {
     router.push('/notifications');
@@ -43,7 +44,7 @@ export default function Notifications() {
     const { notificationType, id, payload, isRead } = notification;
     if (!isRead) {
       await readNotification(id);
-      ApiHelper.get(API_URL.NOTIFICATIONS);
+      notificationQuery.invalidateQueries({ queryKey: ['notifications', 0] });
     }
     moveToNotificationPath(notificationType, payload.problemId, payload.discussionId, router);
     setOpen(false);

--- a/src/widgets/pagination/index.tsx
+++ b/src/widgets/pagination/index.tsx
@@ -1,0 +1,87 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+const PAGE_LIMIT = 10;
+
+interface PaginationProps {
+  currentPage: number;
+  setCurrentPage: (page: number) => void;
+  totalPages: number;
+  isLoading: boolean;
+}
+export default function Pagination({
+  currentPage,
+  setCurrentPage,
+  totalPages,
+  isLoading,
+}: PaginationProps) {
+  const [pageGroupStart, setPageGroupStart] = useState<number>(0); // 0-based group start
+
+  // totalPages는 "페이지 수" (count)라고 가정 -> lastIndex = totalPages - 1
+  const lastIndex = Math.max(totalPages - 1, 0);
+
+  const pageNumbers = useMemo(() => {
+    if (totalPages <= 0) return [];
+    const end = Math.min(pageGroupStart + PAGE_LIMIT - 1, lastIndex);
+    return Array.from({ length: end - pageGroupStart + 1 }, (_, i) => pageGroupStart + i);
+  }, [pageGroupStart, totalPages, lastIndex]);
+
+  // 오른쪽 화살표: 한 그룹 앞으로 (혹은 마지막 인덱스)
+  const handleNextPage = () => {
+    if (pageGroupStart + PAGE_LIMIT <= lastIndex) {
+      setCurrentPage(pageGroupStart + PAGE_LIMIT); // 다음 그룹 시작점
+    } else {
+      setCurrentPage(lastIndex); // 마지막 그룹에서 넘어가면 마지막 페이지로
+    }
+  };
+
+  // currentPage가 page group 범위를 벗어나면 group start 재조정
+  useEffect(() => {
+    if (currentPage < pageGroupStart || currentPage >= pageGroupStart + PAGE_LIMIT) {
+      setPageGroupStart(Math.floor(currentPage / PAGE_LIMIT) * PAGE_LIMIT);
+    }
+  }, [currentPage, pageGroupStart]);
+
+  // 왼쪽 화살표: 한 그룹 뒤로 (혹은 0)
+  const handlePrevPage = () => {
+    const prevGroupEnd = pageGroupStart - 1;
+    if (prevGroupEnd >= 0) {
+      setCurrentPage(prevGroupEnd); // 이전 그룹의 마지막 페이지
+    } else {
+      setCurrentPage(0); // 이미 첫 그룹이면 첫 페이지
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center gap-2 mt-4 text-gray-400">
+      <Button
+        onClick={handlePrevPage}
+        className="p-1 bg-primary disabled:opacity-50 disabled:cursor-not-allowed rounded-[10px] w-10 h-10"
+      >
+        <ChevronLeft className="w-4 h-4" />
+      </Button>
+      {pageNumbers.map((num) => (
+        <Button
+          key={num}
+          onClick={() => {
+            if (!isLoading) setCurrentPage(num);
+          }}
+          className={`w-10 h-10 rounded-md flex items-center justify-center text-sm transition ${
+            currentPage === num
+              ? 'bg-primary text-white border-primary'
+              : 'bg-gray-800 border-gray-700 text-white hover:bg-gray-700'
+          }`}
+        >
+          {num + 1}
+        </Button>
+      ))}
+      <Button
+        onClick={handleNextPage}
+        className="p-1 bg-primary disabled:opacity-50 disabled:cursor-not-allowed rounded-[10px] w-10 h-10"
+      >
+        <ChevronRight className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔎 작업 사항

- 알림 페이지 페이지 네이션
- 읽음 표시 이후 invalidateQuery 수행
- 웹소켓 연결 이전에 get 요청을 보내는 타이밍 레이스 문제가 있어 store에 isConnected 상태 추가, 
이후 해당 상태를 select 구독 하여 쿼리요청의 enabled와 연결이후 요청 재시도가 가능해집니다.

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 페이지에 클라이언트 측 페이지네이션 추가
  * WebSocket 연결 상태 추적 기능 구현

* **버그 수정**
  * 마이페이지에서 문의 탭 제거
  * 디버그 콘솔 로그 제거
  * 비밀번호 변경 탭 헤더 텍스트 수정

* **UI/UX 개선**
  * 문제 테이블 페이지네이션 컴포넌트로 개선
  * 연도 선택 드롭다운 스타일링 및 위치 최적화
  * 알림 로딩 상태 피드백 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->