### PR TITLE
fix: 이미지 용량 초과 파일 요청 막음

### DIFF
--- a/src/app/(auth)/(navigationsBarLayout)/mypage/ui/ModifyForm.tsx
+++ b/src/app/(auth)/(navigationsBarLayout)/mypage/ui/ModifyForm.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/shared/ui/badge/Badge';
 import { Select } from '@/shared/ui/select/Select';
 import Image from 'next/image';
 import { Dispatch, SetStateAction, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 
 type LanguageList = {
   label: string;
@@ -32,7 +33,10 @@ export const ModifyForm = ({
     if (!event.target.files?.length) return;
 
     const file = event.target.files[0];
-    console.log(file);
+    if (file.size > 1024 * 1024 * 5) {
+      toast.info('프로필 이미지는 5MB 이하로 업로드 가능합니다.');
+      return;
+    }
     try {
       setEditForm((prev) => ({
         ...prev,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,7 @@
   }
 }
 
-@layer {
+@layer base {
   * {
     font-family: 'NanumSquare';
   }
@@ -54,8 +54,8 @@
     list-style: none;
   }
   input:-webkit-autofill {
-    box-shadow: 0 0 0px 1000px var(--color-bg200) inset !important;
-    -webkit-text-fill-color: var(--color-gray100) !important;
+    box-shadow: 0 0 0px 1000px var(--color-secondary-background) inset !important;
+    -webkit-text-fill-color: var(--color-white) !important;
     caret-color: var(--color-gray100) !important;
   }
 

--- a/src/entities/submitCode/submission/model/mutation/submitCode.mutation.ts
+++ b/src/entities/submitCode/submission/model/mutation/submitCode.mutation.ts
@@ -11,6 +11,7 @@ import {
 } from './submitCode.mutation.type';
 import { useProblemWebSocketStoreActions } from '@/features/submitCode/submission/model/useProblemWebSocketStore';
 import { PATHS } from '@/constants/paths';
+import { toast } from 'sonner';
 
 //문제 제출하기
 export const useSubmissionForResultMutation = (problemId: ProblemId) => {
@@ -48,6 +49,10 @@ export const useSaveDraftData = (hasAccessToken: boolean) => {
         if (res.data.success) {
           const newVersion = res.data.result.version;
           return newVersion;
+        } else {
+          if (res.data.message) {
+            toast.error(res.data.message);
+          }
         }
       } catch {
         return null;

--- a/src/entities/submitCode/submission/model/query/submitCode.query.ts
+++ b/src/entities/submitCode/submission/model/query/submitCode.query.ts
@@ -53,6 +53,7 @@ export const useGetDraftData = (problemId: ProblemId, laguageId: number) => {
         return null;
       }
     },
+    staleTime: 0,
     enabled: !!problemId && !!laguageId,
   });
 };


### PR DESCRIPTION
## 🔎 작업 사항
- 5MB 이상의 파일 전송시 http 요청 막음
- 자동저장시 중복탭을 띄울 경우 400 배드리퀘스트 발생을 대비하여 서버 메시지 toast로 보여줌 
- <br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 파일 업로드 시 5MB 크기 제한이 추가되어 초과 파일 업로드 시 알림이 표시됩니다.
  * 초안 저장 실패 시 서버 메시지가 포함된 오류 알림이 표시됩니다.

* **스타일**
  * 폼 자동입력 스타일이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->