### PR TITLE
feat: 이메일 인증 리다이렉트 페이지 구현

### DIFF
--- a/src/app/(guest)/email-verify/page.tsx
+++ b/src/app/(guest)/email-verify/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { cn } from '@/lib/utils';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function EmailVerifyPage() {
+  const searchParmas = useSearchParams();
+  const router = useRouter();
+
+  const status = searchParmas.get('status');
+  const errorMessage = searchParmas.get('message');
+  const titleText = status === 'success' ? '성공' : '실패';
+
+  const contentText =
+    status === 'success'
+      ? '잠시후 홈페이지로 이동합니다.'
+      : errorMessage
+        ? errorMessage
+        : '알 수 없는 오류가 발생했습니다, 다시 시도해 주세요.';
+
+  useEffect(() => {
+    if (status === 'success') {
+      const timer = setTimeout(() => {
+        router.replace('/');
+      }, 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [status]);
+
+  return (
+    <div className="w-full h-full flex flex-col justify-center items-center p-4">
+      <h1 className={cn('text-2xl font-bold mb-4', status === 'success' && 'text-secondary')}>
+        이메일 인증에 {titleText}했습니다.
+      </h1>
+      <p className={cn(status === 'success' && 'text-secondary')}>{contentText}</p>
+    </div>
+  );
+}

--- a/src/features/auth/ui/ConditionalNavigationBar.tsx
+++ b/src/features/auth/ui/ConditionalNavigationBar.tsx
@@ -5,7 +5,9 @@ import { usePathname } from 'next/navigation';
 export default function ConditionalNavigationBar({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isAdminRoute = pathname?.startsWith('/admin') || false;
-  if (isAdminRoute) {
+  const isEmailVerifyRoute = pathname?.startsWith('/email-verify') || false;
+
+  if (isAdminRoute || isEmailVerifyRoute) {
     return children;
   }
   return (


### PR DESCRIPTION
## 🔎 작업 사항

- conditinal navigation에서 인증페이지는 헤더 제외 추가
- 성공시 setTimeout으로 홈페이지이동 
- 실패시 쿼리파라미터의 message 보여줌

<br>

## ❗️ 전달 사항

e.g. ) npm i 하세요 ...

<br>

## ➕ 관련 이슈

-
